### PR TITLE
fix: prevent content shift on Model Switcher menu open/close

### DIFF
--- a/components/ui/form-component.tsx
+++ b/components/ui/form-component.tsx
@@ -54,7 +54,7 @@ const ModelSwitcher: React.FC<ModelSwitcherProps> = ({ selectedModel, setSelecte
     const [isOpen, setIsOpen] = useState(false);
 
     return (
-        <DropdownMenu onOpenChange={setIsOpen}>
+        <DropdownMenu onOpenChange={setIsOpen} modal={false}>
             <DropdownMenuTrigger
                 className={cn(
                     "flex items-center justify-center w-8 h-8 rounded-full transition-all duration-300",


### PR DESCRIPTION
Tiny fix to prevent content shift when opening the Model Switcher dropdown-menu.

See: https://github.com/shadcn-ui/ui/issues/149#issuecomment-1760000296

### Before

https://github.com/user-attachments/assets/3d2b9686-4251-45b0-a9c7-9425ea1322f9


### After 

https://github.com/user-attachments/assets/b89f6d19-ad64-48a9-bd69-79251966f86a

