### PR TITLE
Change cursor-help to pointer for citation links

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1036,7 +1036,7 @@ const HomeContent = () => {
                             href={href}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className={isCitation ? "cursor-help text-sm text-primary py-0.5 px-1.5 m-0 bg-neutral-200 dark:bg-neutral-700 rounded-full no-underline" : "text-teal-600 dark:text-teal-400 no-underline hover:underline"}
+                            className={isCitation ? "cursor-pointer text-sm text-primary py-0.5 px-1.5 m-0 bg-neutral-200 dark:bg-neutral-700 rounded-full no-underline" : "text-teal-600 dark:text-teal-400 no-underline hover:underline"}
                         >
                             {text}
                         </Link>

--- a/components/markdown-render.tsx
+++ b/components/markdown-render.tsx
@@ -147,7 +147,7 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content }) => {
                         href={href}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className={isCitation ? "cursor-help text-sm text-primary py-0.5 px-1.5 m-0 bg-neutral-200 dark:bg-neutral-700 rounded-full no-underline" : "text-teal-600 dark:text-teal-400 no-underline hover:underline"}
+                        className={isCitation ? "cursor-pointer text-sm text-primary py-0.5 px-1.5 m-0 bg-neutral-200 dark:bg-neutral-700 rounded-full no-underline" : "text-teal-600 dark:text-teal-400 no-underline hover:underline"}
                     >
                         {text}
                     </Link>


### PR DESCRIPTION
**Before:** Citation links displayed with a help cursor (❓)

![Screenshot 2025-02-14 122949](https://github.com/user-attachments/assets/a90ba9f1-e122-4cf4-ac0c-10bd405d4f74)

**After:** Citation links now display a pointer cursor (👆), indicating they are clickable

![Screenshot 2025-02-14 122909](https://github.com/user-attachments/assets/36946580-f9ab-4d32-a777-63c2b56e470a)

this makes it clearer for users that citation links are clickable, improving the overall user experience.
