### PR TITLE
Include .env in git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,9 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# local env files
+# env files
 .env*.local
+.env
 
 # vercel
 .vercel


### PR DESCRIPTION
closed #87 
I thinks we should ignore .env file as well since the readme ask ppl to write api keys in .env file
<img width="869" alt="image" src="https://github.com/user-attachments/assets/15479369-e601-4c23-92d9-6bdfc5178003" />
<img width="602" alt="image" src="https://github.com/user-attachments/assets/3bbd10ba-844f-4c54-b580-5aab9f266b69" />
