### PR TITLE
Fix: Restore Textarea Height After Submission

### DIFF
--- a/components/ui/form-component.tsx
+++ b/components/ui/form-component.tsx
@@ -640,6 +640,15 @@ const FormComponent: React.FC<FormComponentProps> = ({
     const [isFocused, setIsFocused] = useState(false);
     const [isDragging, setIsDragging] = useState(false);
 
+    useEffect(() => {
+        if (hasSubmitted) {
+            setInput(""); // Limpa o input
+            if (inputRef.current) {
+                inputRef.current.style.height = "72px"; // Define altura mínima padrão
+            }
+        }
+    }, [hasSubmitted]);
+
     // Add a ref to track the initial group selection
     const initialGroupRef = useRef(selectedGroup);
 
@@ -1007,6 +1016,7 @@ const FormComponent: React.FC<FormComponentProps> = ({
                         maxHeight: `${MAX_HEIGHT}px`,
                         WebkitUserSelect: 'text',
                         WebkitTouchCallout: 'none',
+                        height: "auto",
                     }}
                     rows={1}
                     autoFocus={width ? width > 768 : true}


### PR DESCRIPTION
This PR ensures that the input field (`Textarea`) returns to its original height after a message is submitted. Previously, if a long message was entered, the field would remain expanded even after submission, leading to an inconsistent UI.

# Changes Implemented:
✅ Reset input value after submission.
✅ Restore `Textarea` height to its initial size (`72px`) using `useEffect`.
✅ Ensure dynamic height adjustment when typing.

## How it Works:
When a message is submitted, the `useEffect` hook detects the change in `hasSubmitted` and resets both the input value and height.
This prevents excessive stretching of the input field after submitting long messages.

## Before:
🔴 Textarea remained enlarged after sending a long message.

## After:
🟢 Textarea resets to default height after submission, improving usability and UI consistency.