### PR TITLE
fix: use resolvedTheme for accurate theme management

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -728,13 +728,13 @@ const HomeContent = () => {
     }, [initialState.query, append, setInput, messages.length]);
 
     const ThemeToggle: React.FC = () => {
-        const { theme, setTheme } = useTheme();
+        const { resolvedTheme, setTheme } = useTheme();
 
         return (
             <Button
                 variant="ghost"
                 size="icon"
-                onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+                onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}
                 className="bg-transparent hover:bg-neutral-100 dark:hover:bg-neutral-800"
             >
                 <Sun className="h-5 w-5 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />


### PR DESCRIPTION
Currently, when `enableSystem` is set, 

https://github.com/zaidmukaddam/scira/blob/83d73d710f3d747879bac5df3f83d4fc305282af/app/providers.tsx#L19-L24

the theme parameter returns `system` instead of `light` or `dark`. This causes an issue where new users (those without a saved theme preference in localStorage) cannot change the theme on their first click. To reproduce the issue, clear cookies and try toggling the theme.

https://github.com/user-attachments/assets/f1ab2241-2c37-4bc1-9c79-8d5ea664aff0

As stated in the [next-themes docs](https://github.com/pacocoursey/next-themes?tab=readme-ov-file#usetheme-1), 
when `enableSystem` is `true` and the active theme is `system`, theme remains `system` while resolvedTheme returns whether the system preference is resolved to `dark` or `light`.

The new implementation is similar to the one done by shadcn:
https://github.com/shadcn-ui/ui/blob/12d4cf2ab0caefec5d6232e6c32220a8e62d73c4/apps/v4/components/mode-toggle.tsx#L10