### PR TITLE
feat: migrate next config from .mjs to .ts 

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,9 +4,9 @@ import './env/client';
 
 const nextConfig: NextConfig = {
     experimental: {
-        optimizePackageImports: ['@phosphor-icons/react'],
+        optimizePackageImports: ["@phosphor-icons/react"],
     },
-    transpilePackages: ['geist'],
+    transpilePackages: ["geist"],
     output: 'standalone',
     async headers() {
         return [
@@ -27,7 +27,7 @@ const nextConfig: NextConfig = {
                     },
                 ],
             },
-        ];
+        ]
     },
     async redirects() {
         return [
@@ -40,8 +40,8 @@ const nextConfig: NextConfig = {
                 source: '/raycast',
                 destination: 'https://www.raycast.com/zaidmukaddam/scira',
                 permanent: true,
-            },
-        ];
+            }
+        ]
     },
     images: {
         dangerouslyAllowSVG: true,
@@ -50,13 +50,13 @@ const nextConfig: NextConfig = {
                 protocol: 'https',
                 hostname: '**',
                 port: '',
-                pathname: '**',
+                pathname: '**'
             },
             {
                 protocol: 'http',
                 hostname: '**',
                 port: '',
-                pathname: '**',
+                pathname: '**'
             },
             {
                 protocol: 'https',
@@ -74,44 +74,44 @@ const nextConfig: NextConfig = {
                 protocol: 'https',
                 hostname: 'metwm7frkvew6tn1.public.blob.vercel-storage.com',
                 port: '',
-                pathname: '**',
+                pathname: "**"
             },
             // upload.wikimedia.org
             {
                 protocol: 'https',
                 hostname: 'upload.wikimedia.org',
                 port: '',
-                pathname: '**',
+                pathname: '**'
             },
             // media.theresanaiforthat.com
             {
                 protocol: 'https',
                 hostname: 'media.theresanaiforthat.com',
                 port: '',
-                pathname: '**',
+                pathname: '**'
             },
             // www.uneed.best
             {
                 protocol: 'https',
                 hostname: 'www.uneed.best',
                 port: '',
-                pathname: '**',
+                pathname: '**'
             },
             // image.tmdb.org
             {
                 protocol: 'https',
                 hostname: 'image.tmdb.org',
                 port: '',
-                pathname: '/t/p/original/**',
+                pathname: '/t/p/original/**'
             },
             // image.tmdb.org
             {
                 protocol: 'https',
                 hostname: 'image.tmdb.org',
                 port: '',
-                pathname: '/**',
+                pathname: '/**'
             },
-        ],
+        ]
     },
 };
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,18 +1,12 @@
-// https://env.t3.gg/docs/nextjs#validate-schema-on-build-(recommended)
-import { createJiti } from 'jiti'
-import { fileURLToPath } from 'node:url'
-const jiti = createJiti(fileURLToPath(import.meta.url))
+import type { NextConfig } from 'next';
+import './env/server';
+import './env/client';
 
-// Import env here to validate during build. Using jiti we can import .ts files :)
-jiti.import('./env/server')
-jiti.import('./env/client')
-
-/** @type {import('next').NextConfig} */
-const nextConfig = {
+const nextConfig: NextConfig = {
     experimental: {
-        optimizePackageImports: ["@phosphor-icons/react"],
+        optimizePackageImports: ['@phosphor-icons/react'],
     },
-    transpilePackages: ["geist"],
+    transpilePackages: ['geist'],
     output: 'standalone',
     async headers() {
         return [
@@ -33,7 +27,7 @@ const nextConfig = {
                     },
                 ],
             },
-        ]
+        ];
     },
     async redirects() {
         return [
@@ -46,8 +40,8 @@ const nextConfig = {
                 source: '/raycast',
                 destination: 'https://www.raycast.com/zaidmukaddam/scira',
                 permanent: true,
-            }
-        ]
+            },
+        ];
     },
     images: {
         dangerouslyAllowSVG: true,
@@ -56,13 +50,13 @@ const nextConfig = {
                 protocol: 'https',
                 hostname: '**',
                 port: '',
-                pathname: '**'
+                pathname: '**',
             },
             {
                 protocol: 'http',
                 hostname: '**',
                 port: '',
-                pathname: '**'
+                pathname: '**',
             },
             {
                 protocol: 'https',
@@ -80,44 +74,44 @@ const nextConfig = {
                 protocol: 'https',
                 hostname: 'metwm7frkvew6tn1.public.blob.vercel-storage.com',
                 port: '',
-                pathname: "**"
+                pathname: '**',
             },
             // upload.wikimedia.org
             {
                 protocol: 'https',
                 hostname: 'upload.wikimedia.org',
                 port: '',
-                pathname: '**'
+                pathname: '**',
             },
             // media.theresanaiforthat.com
             {
                 protocol: 'https',
                 hostname: 'media.theresanaiforthat.com',
                 port: '',
-                pathname: '**'
+                pathname: '**',
             },
             // www.uneed.best
             {
                 protocol: 'https',
                 hostname: 'www.uneed.best',
                 port: '',
-                pathname: '**'
+                pathname: '**',
             },
             // image.tmdb.org
             {
                 protocol: 'https',
                 hostname: 'image.tmdb.org',
                 port: '',
-                pathname: '/t/p/original/**'
+                pathname: '/t/p/original/**',
             },
             // image.tmdb.org
             {
                 protocol: 'https',
                 hostname: 'image.tmdb.org',
                 port: '',
-                pathname: '/**'
+                pathname: '/**',
             },
-        ]
+        ],
     },
 };
 


### PR DESCRIPTION
## 📝 Summary
Migrates the Next.js configuration from `next.config.mjs` to `next.config.ts` to leverage Next.js 15's native TypeScript support for configuration files.

## Changes
- **File Migration**: Converted `next.config.mjs` → `next.config.ts`
- **Type Safety**: Added proper `NextConfig` type annotation
- **Import Simplification**: Replaced jiti-based dynamic imports with direct TypeScript imports

##  Technical Details
### Before (next.config.mjs)
- Used jiti for importing TypeScript files at build time
- Required additional runtime dependencies
- JSDoc type annotations

### After (next.config.ts)
- Native TypeScript support (Next.js 15)
- Direct imports without jiti wrapper
- Proper TypeScript typing with `NextConfig`
- Cleaner, more maintainable code

## 🔗 Resource Link
[Next 15 Release Note](https://nextjs.org/blog/next-15)
