### PR TITLE
feat: Add sparkle background effect when I am working

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -307,6 +307,61 @@
   --sidebar-ring: oklch(0.556 0 0);
 }
 
+@keyframes sparkle {
+  0%, 100% {
+    opacity: 0;
+    transform: scale(0.5) translate(-50%, -50%);
+  }
+  25%, 75% {
+    opacity: 0.8;
+    transform: scale(1) translate(-50%, -50%);
+  }
+  50% {
+    opacity: 0.4;
+    transform: scale(0.75) translate(-50%, -50%);
+  }
+}
+
+.sparkle-background {
+  position: relative;
+  overflow: hidden;
+}
+
+.sparkle-background::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  background-image: radial-gradient(circle, oklch(1 0 0 / 0.5) 1px, transparent 1px);
+  background-size: 50px 50px; /* Adjust density of sparkles */
+  animation: sparkle-animation 20s linear infinite;
+}
+
+@keyframes sparkle-animation {
+  0% {
+    transform: translate(0, 0);
+    opacity: 0;
+  }
+  20% {
+    opacity: 0.7;
+  }
+  100% {
+    transform: translate(25px, 25px); /* Creates movement */
+    opacity: 0;
+  }
+}
+
+/* Ensure dark theme compatibility by adjusting sparkle color if needed,
+   though a semi-transparent white should generally work.
+   If a specific dark theme sparkle is needed, uncomment and adjust:
+.dark .sparkle-background::before {
+  background-image: radial-gradient(circle, oklch(0.2 0 0 / 0.5) 1px, transparent 1px);
+}
+*/
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/components/chat-interface.tsx
+++ b/components/chat-interface.tsx
@@ -70,6 +70,7 @@ const ChatInterface = memo(({ initialChatId, initialMessages, initialVisibility 
     const isAutoScrollingRef = useRef(false);
     const [user, setUser] = useState<User | null>(null);
     const [userLoading, setUserLoading] = useState(true);
+    const [isSparkling, setIsSparkling] = useState(false);
 
     // Generate random UUID once for greeting selection
     const greetingUuidRef = useRef<string>(uuidv4());
@@ -217,6 +218,15 @@ const ChatInterface = memo(({ initialChatId, initialMessages, initialVisibility 
         error,
         experimental_resume
     } = useChat(chatOptions);
+
+    useEffect(()
+ => {
+        if (status === 'loading' || status === 'streaming') {
+            setIsSparkling(true);
+        } else {
+            setIsSparkling(false);
+        }
+    }, [status]);
 
     useAutoResume({
         autoResume: true,
@@ -394,7 +404,10 @@ const ChatInterface = memo(({ initialChatId, initialMessages, initialVisibility 
 
     return (
         <TooltipProvider>
-            <div className="flex flex-col font-sans! items-center min-h-screen bg-background text-foreground transition-all duration-500">
+            <div className={cn(
+                "flex flex-col font-sans! items-center min-h-screen bg-background text-foreground transition-all duration-500",
+                isSparkling && "sparkle-background"
+            )}>
                 <Navbar
                     isDialogOpen={anyDialogOpen}
                     chatId={initialChatId || (messages.length > 0 ? chatId : null)}


### PR DESCRIPTION
This commit introduces a visual sparkle effect to the chat interface background that activates when I am processing or streaming a response.

The following changes were made:

1.  A new CSS animation (`sparkle-animation`) and a corresponding class (`sparkle-background`) were added to `app/globals.css`. This animation creates a subtle, theme-compatible sparkle effect using a pseudo-element with a radial gradient.
2.  The `components/chat-interface.tsx` was modified to:
    *   Include an `isSparkling` state variable.
    *   Use a `useEffect` hook to update `isSparkling` based on the `status` from the `useChat` hook (`loading` or `streaming` will activate the effect).
    *   Conditionally apply the `sparkle-background` class to the main container div, making the background sparkle when I am active.