### PR TITLE
Update sandbox.py for Daytona Sandbox SDK version v0.21.0

### DIFF
--- a/sandbox.py
+++ b/sandbox.py
@@ -1,18 +1,33 @@
-from daytona_sdk import Daytona, DaytonaConfig, Image
+from daytona import Daytona, DaytonaConfig, Image, CreateSnapshotParams, Resources
 import time
 
-daytona = Daytona(DaytonaConfig(api_key=""))
+daytona = Daytona(DaytonaConfig(api_key="DAYTONA_API_KEY"))
 
 # Generate a unique name for the image
-image_name = f"scira-analysis:{int(time.time())}"
+snapshot_name = f"scira-analysis:1749316515"
 
 # Create a Python image
 image = (
     Image.debian_slim("3.12")
     .pip_install(["numpy", "pandas", "matplotlib", "scipy", "scikit-learn", "yfinance", "requests", "keras", "uv"])
-    .run_commands(["apt-get update && apt-get install -y git curl", "mkdir -p /home/daytona/project"])
+    .run_commands(
+        "apt-get update && apt-get install -y git",
+        "groupadd -r daytona && useradd -r -g daytona -m daytona",
+        "mkdir -p /home/daytona/workspace",
+    )
 )
 
 # Create the image and stream the build logs
-print(f"=== Creating Image: {image_name} ===")
-daytona.create_image(image_name, image, on_logs=lambda log_line: print(log_line, end=''), timeout=0)
+print(f"=== Creating Image: {snapshot_name} ===")
+daytona.snapshot.create(
+    CreateSnapshotParams(
+        name=snapshot_name,
+        image=image,
+        resources=Resources(
+            cpu=1,
+            memory=1,
+            disk=3,
+        ),
+    ),
+    on_logs=print,
+)


### PR DESCRIPTION
This PR modifies sandbox.py to work with Daytona Sandbox SDK v0.21.0, replacing the old image builder(deprecated in v0.20.2) with the new snapshots(Formerly known as Image)

- Update Compatible sandbox.py for Daytona Sandbox SDK version v0.21.0
