### PR TITLE
Add GOOGLE_GENERATIVE_AI_API_KEY to .env.example (issue #159)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,15 +3,13 @@ XAI_API_KEY=your_xai_api_key_here
 OPENAI_API_KEY=your_openai_api_key_here
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
 GROQ_API_KEY=your_groq_api_key_here
-
+GOOGLE_GENERATIVE_AI_API_KEY=your_google_generative_ai_api_key_here   
 # Development & Sandbox
 DAYTONA_API_KEY=your_daytona_api_key_here
-
 # Database & Storage
 DATABASE_URL=your_database_url_here
 REDIS_URL=your_redis_url_here
 BLOB_READ_WRITE_TOKEN=your_blob_token_here
-
 # Authentication
 BETTER_AUTH_SECRET=your_secret_key_here
 GITHUB_CLIENT_ID=your_github_client_id_here
@@ -20,35 +18,28 @@ GOOGLE_CLIENT_ID=your_google_client_id_here
 GOOGLE_CLIENT_SECRET=your_google_client_secret_here
 TWITTER_CLIENT_ID=your_twitter_client_id_here
 TWITTER_CLIENT_SECRET=your_twitter_client_secret_here
-
 # Search & Web APIs
 TAVILY_API_KEY=your_tavily_api_key_here
 EXA_API_KEY=your_exa_api_key_here
 FIRECRAWL_API_KEY=your_firecrawl_api_key_here
-
 # Media & Entertainment
 TMDB_API_KEY=your_tmdb_api_key_here
 YT_ENDPOINT=your_youtube_endpoint_here
 ELEVENLABS_API_KEY=your_elevenlabs_api_key_here
-
 # Maps & Location
 GOOGLE_MAPS_API_KEY=your_google_maps_api_key_here
 MAPBOX_ACCESS_TOKEN=your_mapbox_access_token_here
 TRIPADVISOR_API_KEY=your_tripadvisor_api_key_here
-
 # Weather & Aviation
 OPENWEATHER_API_KEY=your_openweather_api_key_here
 AVIATION_STACK_API_KEY=your_aviation_stack_api_key_here
-
 # Memory & MCP
 MEM0_API_KEY=your_mem0_api_key_here
 MEM0_ORG_ID=your_mem0_org_id_here
 MEM0_PROJECT_ID=your_mem0_project_id_here
 SMITHERY_API_KEY=your_smithery_api_key_here
-
 # Cron & Security
 CRON_SECRET=your_cron_secret_here
-
 # Client-side Environment Variables (NEXT_PUBLIC_*)
 NEXT_PUBLIC_MAPBOX_TOKEN=your_public_mapbox_token_here
 NEXT_PUBLIC_POSTHOG_KEY=your_posthog_key_here


### PR DESCRIPTION
This PR adds the GOOGLE_GENERATIVE_AI_API_KEY variable to the .env.example file, addressing issue #159.

After reviewing the variables listed in the issue, I found that the other mentioned variables (OPENAI_API_KEY, ANTHROPIC_API_KEY, GROQ_API_KEY, DAYTONA_API_KEY, SMITHERY_API_KEY) were already present in the .env.example file. Therefore, only GOOGLE_GENERATIVE_AI_API_KEY needed to be added to ensure the example file is up to date and complete for new contributors.