### PR TITLE
Fix missing environment variables in .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,3 +66,4 @@ NEXT_PUBLIC_POSTHOG_HOST=https://your-posthog-host.com
 NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=your_public_google_maps_api_key_here
 NEXT_PUBLIC_PREMIUM_TIER=your_premium_tier_value_here
 NEXT_PUBLIC_PREMIUM_SLUG=your_premium_slug_value_here
+NEXT_PUBLIC_STARTER_TIER=your_starter_tier_value_here

--- a/.env.example
+++ b/.env.example
@@ -58,7 +58,7 @@ SMITHERY_API_KEY=your_smithery_api_key_here
 
 # Cron & Security
 CRON_SECRET=your_cron_secret_here
-
+POLAR_WEBHOOK_SECRET=your_polar_webhook_secret_here
 # Client-side Environment Variables (NEXT_PUBLIC_*)
 NEXT_PUBLIC_MAPBOX_TOKEN=your_public_mapbox_token_here
 NEXT_PUBLIC_POSTHOG_KEY=your_posthog_key_here
@@ -67,3 +67,4 @@ NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=your_public_google_maps_api_key_here
 NEXT_PUBLIC_PREMIUM_TIER=your_premium_tier_value_here
 NEXT_PUBLIC_PREMIUM_SLUG=your_premium_slug_value_here
 NEXT_PUBLIC_STARTER_TIER=your_starter_tier_value_here
+NEXT_PUBLIC_STARTER_SLUG=your_starter_slug_value_here

--- a/.env.example
+++ b/.env.example
@@ -64,3 +64,4 @@ NEXT_PUBLIC_MAPBOX_TOKEN=your_public_mapbox_token_here
 NEXT_PUBLIC_POSTHOG_KEY=your_posthog_key_here
 NEXT_PUBLIC_POSTHOG_HOST=https://your-posthog-host.com
 NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=your_public_google_maps_api_key_here
+NEXT_PUBLIC_PREMIUM_TIER=your_premium_tier_value_here

--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ GOOGLE_GENERATIVE_AI_API_KEY=api_key
 
 # Development & Sandbox
 DAYTONA_API_KEY=your_daytona_api_key_here
+SANDBOX_TEMPLATE_ID=your_sandbox_template_id_here
 
 # Database & Storage
 DATABASE_URL=your_database_url_here

--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,8 @@ GOOGLE_GENERATIVE_AI_API_KEY=api_key
 DAYTONA_API_KEY=your_daytona_api_key_here
 SANDBOX_TEMPLATE_ID=your_sandbox_template_id_here
 
+DODO_PAYMENTS_API_KEY=your_dodo_payments_api_key_here
+
 # Database & Storage
 DATABASE_URL=your_database_url_here
 REDIS_URL=your_redis_url_here

--- a/.env.example
+++ b/.env.example
@@ -65,3 +65,4 @@ NEXT_PUBLIC_POSTHOG_KEY=your_posthog_key_here
 NEXT_PUBLIC_POSTHOG_HOST=https://your-posthog-host.com
 NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=your_public_google_maps_api_key_here
 NEXT_PUBLIC_PREMIUM_TIER=your_premium_tier_value_here
+NEXT_PUBLIC_PREMIUM_SLUG=your_premium_slug_value_here

--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,12 @@ TMDB_API_KEY=your_tmdb_api_key_here
 YT_ENDPOINT=your_youtube_endpoint_here
 ELEVENLABS_API_KEY=your_elevenlabs_api_key_here
 
+# Travel & Crypto APIs
+AMADEUS_API_KEY=your_amadeus_api_key_here
+AMADEUS_API_SECRET=your_amadeus_api_secret_here
+COINGECKO_API_KEY=your_coingecko_api_key_here
+
+
 # Maps & Location
 GOOGLE_MAPS_API_KEY=your_google_maps_api_key_here
 MAPBOX_ACCESS_TOKEN=your_mapbox_access_token_here


### PR DESCRIPTION
# Summary

This PR fixes a build issue in Docker caused by missing environment variables in the `.env` file.

## Changes

The following environment keys were added to `.env` and `.env.example`:

- `SANDBOX_TEMPLATE_ID`
- `AMADEUS_API_KEY`
- `AMADEUS_API_SECRET`
- `COINGECKO_API_KEY`
## Impact

The build now succeeds in Docker, resolving the previous environment validation errors.

Closes #179

> This issue was originally reported in [#179: Invalid environment variables](https://github.com/zaidmukaddam/scira/issues/179)
