### PR TITLE
feat: upgrade stock mode

### DIFF
--- a/components/interactive-stock-chart.tsx
+++ b/components/interactive-stock-chart.tsx
@@ -3,11 +3,15 @@ import ReactECharts, { EChartsOption } from 'echarts-for-react';
 import { Badge } from '@/components/ui/badge';
 import { useTheme } from 'next-themes';
 import { cn } from '@/lib/utils';
-import { ArrowUpRight, ArrowDownRight, ExternalLink, Newspaper } from 'lucide-react';
+import { ArrowUpRight, ArrowDownRight, ExternalLink, Newspaper, TrendingUp, TrendingDown, Target, Calendar, ChevronDown, ChevronUp, BarChart3, List, FileText, Building2, DollarSign, Activity, Wallet, Banknote, UserCheck, TrendingUp as TrendingUpIcon, Percent, LineChart } from 'lucide-react';
 import { ChartBar } from '@phosphor-icons/react';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
 import { HugeiconsIcon } from '@hugeicons/react';
 import { Chart03Icon } from '@hugeicons/core-free-icons';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { MarkdownRenderer } from '@/components/markdown';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 // Currency symbol mapping with modern design tokens
 const CURRENCY_SYMBOLS = {
@@ -56,9 +60,9 @@ const getSeriesColor = (index: number) => {
 interface StockChartProps {
   title: string;
   data: any[];
-  stock_symbols: string[];
+  stock_symbols?: string[]; // Keep for backward compatibility
   currency_symbols: string[];
-  interval: '1d' | '5d' | '1mo' | '3mo' | '6mo' | '1y' | '2y' | '5y' | '10y' | 'ytd' | 'max';
+  interval: string; // Now accepts natural language intervals
   chart: {
     type: string;
     x_label: string;
@@ -66,8 +70,33 @@ interface StockChartProps {
     x_scale: string;
     x_ticks?: string[];
     x_tick_labels?: string[];
-    elements: Array<{ label: string; points: Array<[string, number]> }>;
+    elements: Array<{ label: string; points: Array<[string, number]>; ticker?: string }>;
   };
+  resolved_companies?: Array<{
+    name: string;
+    ticker: string;
+  }>;
+  earnings_data?: Array<{
+    ticker: string;
+    companyName: string;
+    earnings: Array<{
+      date: string;
+      time: string;
+      eps_estimate: number | null;
+      eps_actual: number;
+      difference: number | null;
+      surprise_prc: number | null;
+    }>;
+    metadata?: {
+      symbol?: string;
+      name?: string;
+      start_date?: string;
+      end_date?: string;
+      timestamp?: string;
+      total_results?: number;
+      exchange?: string;
+    };
+  }>;
   news_results?: Array<{
     query: string;
     topic: string;
@@ -80,6 +109,63 @@ interface StockChartProps {
       query: string;
     }>;
   }>;
+  sec_filings?: Array<{
+    id?: string;
+    title: string;
+    url: string;
+    content: string;
+    metadata?: {
+      accession_number?: string;
+      full_filing?: boolean;
+      filing_date?: string; // YYYYMMDD format
+      date?: string; // YYYY-MM-DD format (alternative field)
+      document_type?: string;
+      form_type?: string; // Alternative field name
+      name?: string;
+      ticker?: string;
+      cik?: string;
+      part?: string;
+      item?: string;
+      timestamp?: string;
+    };
+    requestedCompany: string;
+    requestedFilingType: string;
+  }>;
+  company_statistics?: Record<string, any>;
+  balance_sheets?: Record<string, any[]>;
+  income_statements?: Record<string, any[]>;
+  cash_flows?: Record<string, any[]>;
+  dividends_data?: Record<string, any[]>;
+  insider_transactions?: Record<string, any[]>;
+  market_movers?: {
+    gainers: Array<{
+      symbol: string;
+      name: string;
+      exchange: string;
+      last: number;
+      change: number;
+      percent_change: number;
+      volume: number;
+    }>;
+    losers: Array<{
+      symbol: string;
+      name: string;
+      exchange: string;
+      last: number;
+      change: number;
+      percent_change: number;
+      volume: number;
+    }>;
+    most_active: Array<{
+      symbol: string;
+      name: string;
+      exchange: string;
+      last: number;
+      change: number;
+      percent_change: number;
+      volume: number;
+    }>;
+  };
 }
 
 interface ProcessedSeriesData {
@@ -117,14 +203,16 @@ const formatStockSymbol = (symbol: string) => {
   return formatted;
 };
 
-const getDateFormat = (interval: StockChartProps['interval'], date: Date, isMobile: boolean = false) => {
-  if (interval === '1d') {
+const getDateFormat = (interval: string, date: Date, isMobile: boolean = false) => {
+  // Check for short time periods that might need hourly format
+  if (interval.includes('day') && (interval.includes('1') || interval === '1d')) {
     return date.toLocaleTimeString('en-US', { hour: 'numeric' });
   }
-  if (interval === '5d') {
+  // Check for very short periods (like 5 days)
+  if ((interval.includes('day') && interval.includes('5')) || interval === '5d') {
     return date.toLocaleDateString('en-US', { weekday: 'short' });
   }
-  // Format month and two-digit year
+  // Default to month/year format for most other cases
   const month = date.toLocaleDateString('en-US', { month: 'short' });
   const year = date.toLocaleDateString('en-US', { year: '2-digit' });
   const formatted = `${month} ${year}`;
@@ -147,12 +235,65 @@ const formatCurrency = (value: number, currencyCode: string) => {
   }
 };
 
+// Helper function to parse various date formats from SEC filings
+const parseSecFilingDate = (dateStr: string): Date => {
+  // Handle ISO format (YYYY-MM-DD)
+  if (dateStr.includes('-')) {
+    return new Date(dateStr);
+  }
+  
+  // Handle YYYYMMDD format
+  if (dateStr.length === 8) {
+    const year = dateStr.slice(0, 4);
+    const month = dateStr.slice(4, 6);
+    const day = dateStr.slice(6, 8);
+    return new Date(`${year}-${month}-${day}`);
+  }
+  
+  // Fallback to native Date parsing
+  return new Date(dateStr);
+};
+
+// Helper to get filing date from metadata (handles different field names)
+const getFilingDate = (metadata: any): string | null => {
+  return metadata?.filing_date || metadata?.date || null;
+};
+
 export const InteractiveStockChart = React.memo(
-  ({ title, data, stock_symbols, currency_symbols, interval, chart, news_results }: StockChartProps) => {
+  ({ title, data, stock_symbols, currency_symbols, interval, chart, resolved_companies, earnings_data, news_results, sec_filings, company_statistics, balance_sheets, income_statements, cash_flows, dividends_data, insider_transactions, market_movers }: StockChartProps) => {
     const { resolvedTheme } = useTheme();
     const isDark = resolvedTheme === 'dark';
     const [lastUpdated, setLastUpdated] = useState<string>('');
     const [isMobile, setIsMobile] = useState<boolean>(false);
+    const [earningsViewMode, setEarningsViewMode] = useState<'reports' | 'chart'>('reports');
+    const [expandedCompanies, setExpandedCompanies] = useState<Set<string>>(new Set());
+    const [expandedDividendCompanies, setExpandedDividendCompanies] = useState<Set<string>>(new Set());
+
+    // Toggle company expansion
+    const toggleCompanyExpansion = useCallback((ticker: string) => {
+      setExpandedCompanies(prev => {
+        const newSet = new Set(prev);
+        if (newSet.has(ticker)) {
+          newSet.delete(ticker);
+        } else {
+          newSet.add(ticker);
+        }
+        return newSet;
+      });
+    }, []);
+
+    // Toggle dividends company expansion
+    const toggleDividendExpansion = useCallback((company: string) => {
+      setExpandedDividendCompanies(prev => {
+        const next = new Set(prev);
+        if (next.has(company)) {
+          next.delete(company);
+        } else {
+          next.add(company);
+        }
+        return next;
+      });
+    }, []);
 
     // Set last updated time and check if device is mobile
     useEffect(() => {
@@ -173,14 +314,21 @@ export const InteractiveStockChart = React.memo(
     // Process chart data
     const processedData = useMemo((): ProcessedSeriesData[] => {
       return chart.elements.map((element, index) => {
+        // Extract ticker/symbol from various sources
+        const ticker = element.ticker || 
+                      resolved_companies?.[index]?.ticker || 
+                      stock_symbols?.[index] || 
+                      element.label.split(' ')[0] || // fallback to first word of label
+                      'N/A';
+        
         const points = element.points
           .map(([dateStr, price]) => {
             const date = new Date(dateStr);
             return {
               date,
               value: Number(price),
-              label: stock_symbols[index],
-              currency: currency_symbols[index],
+              label: ticker,
+              currency: currency_symbols[index] || 'USD',
             };
           })
           .sort((a, b) => a.date.getTime() - b.date.getTime());
@@ -192,17 +340,17 @@ export const InteractiveStockChart = React.memo(
         const seriesColor = getSeriesColor(index);
 
         return {
-          label: formatStockSymbol(stock_symbols[index]),
+          label: element.label, // Use the full label from Valyu (includes company name)
           points,
           firstPrice,
           lastPrice,
           priceChange,
           percentChange,
           color: seriesColor,
-          currency: currency_symbols[index],
+          currency: currency_symbols[index] || 'USD',
         };
       });
-    }, [chart.elements, stock_symbols, currency_symbols]);
+    }, [chart.elements, stock_symbols, currency_symbols, resolved_companies]);
 
     // Calculate total change
     const totalChange = useMemo(() => {
@@ -442,6 +590,173 @@ export const InteractiveStockChart = React.memo(
       };
     }, [processedData, interval, getTooltipFormatter, isDark, isMobile]);
 
+    // Process earnings data for individual chart visualization per company
+    const createEarningsChartForCompany = useCallback((company: any, companyIndex: number) => {
+      const textColor = isDark ? 'rgba(255, 255, 255, 0.85)' : 'rgba(0, 0, 0, 0.85)';
+      const subTextColor = isDark ? 'rgba(255, 255, 255, 0.45)' : 'rgba(0, 0, 0, 0.45)';
+      const gridColor = isDark ? 'rgba(255, 255, 255, 0.05)' : 'rgba(0, 0, 0, 0.05)';
+      const color = getSeriesColor(companyIndex);
+      
+      // Sort earnings by date for proper timeline
+      const sortedEarnings = [...company.earnings].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+      
+      const actualData = sortedEarnings.map(earning => [new Date(earning.date).getTime(), earning.eps_actual]);
+      const estimateData = sortedEarnings
+        .filter(earning => earning.eps_estimate !== null)
+        .map(earning => [new Date(earning.date).getTime(), earning.eps_estimate]);
+
+      const series = [
+        {
+          name: 'Actual',
+          type: 'line' as const,
+          data: actualData,
+          lineStyle: { color: color.line, width: 1 },
+          itemStyle: { color: color.line },
+          showSymbol: false,
+          smooth: true,
+          emphasis: { focus: 'series' },
+          areaStyle: {
+            color: color.area,
+            opacity: 0.3,
+          },
+        },
+        ...(estimateData.length > 0 ? [{
+          name: 'Estimate',
+          type: 'line' as const,
+          data: estimateData,
+          lineStyle: { 
+            color: color.line, 
+            width: 1, 
+            type: 'dashed' as const,
+            opacity: 0.7
+          },
+          itemStyle: { color: color.line, opacity: 0.7 },
+          showSymbol: false,
+          smooth: true,
+          emphasis: { focus: 'series' },
+        }] : [])
+      ];
+
+      const option: EChartsOption = {
+        backgroundColor: 'transparent',
+        grid: {
+          top: 35,
+          right: 5,
+          bottom: 25,
+          left: 5,
+          containLabel: true,
+        },
+        tooltip: {
+          trigger: 'axis',
+          backgroundColor: 'transparent',
+          borderWidth: 0,
+          borderRadius: 999,
+          padding: 0,
+          formatter: (params: any) => {
+            if (!Array.isArray(params) || params.length === 0) return '';
+            
+            const date = new Date(params[0].value[0]);
+            const day = date.getDate().toString().padStart(2, '0');
+            const month = date.toLocaleDateString('en-US', { month: 'short' });
+            const year = date.getFullYear().toString().slice(-2);
+            const formattedDate = `${day}/${month}/${year}`;
+            
+            let tooltipHtml = `
+              <div style="
+                padding: 4px 10px;
+                border-radius: 999px;
+                font-family: system-ui, sans-serif;
+                background: ${isDark ? 'rgba(32, 32, 36, 0.85)' : 'rgba(255, 255, 255, 0.85)'};
+                box-shadow: 0 2px 8px ${isDark ? 'rgba(0, 0, 0, 0.25)' : 'rgba(0, 0, 0, 0.1)'};
+                font-size: 11px;
+                white-space: nowrap;
+                border: 1px solid ${isDark ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.05)'};
+                display: flex;
+                align-items: center;
+                gap: 6px;
+              ">
+                <span style="
+                  color: ${isDark ? 'rgba(255, 255, 255, 0.6)' : 'rgba(0, 0, 0, 0.6)'};
+                  font-size: 10px;
+                ">${formattedDate}</span>
+            `;
+
+            params.forEach((param: any, index: number) => {
+              const value = param.value[1];
+              const lineColor = param.color;
+              const isEstimate = param.seriesName === 'Estimate';
+
+              tooltipHtml += `
+                ${index > 0 ? '<span style="color: rgba(127, 127, 127, 0.5); margin: 0 -2px;">|</span>' : ''}
+                <div style="
+                  width: 6px;
+                  height: 6px;
+                  border-radius: 50%;
+                  background-color: ${lineColor};
+                  ${isEstimate ? 'opacity: 0.8;' : ''}
+                "></div>
+                <span style="
+                  color: ${isDark ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.9)'};
+                  font-weight: ${index === 0 ? '600' : '400'};
+                  font-size: ${index === 0 ? '11px' : '10px'};
+                ">$${value.toFixed(2)}</span>
+              `;
+            });
+
+            tooltipHtml += '</div>';
+            return tooltipHtml;
+          },
+          axisPointer: {
+            type: 'line',
+            lineStyle: {
+              color: isDark ? 'rgba(255, 255, 255, 0.15)' : 'rgba(0, 0, 0, 0.15)',
+              width: 1,
+            },
+          },
+        },
+        legend: {
+          show: estimateData.length > 0,
+          top: 5,
+          right: 10,
+          textStyle: { color: subTextColor, fontSize: 9 },
+          itemGap: 10,
+          itemWidth: 12,
+          itemHeight: 8,
+        },
+        xAxis: {
+          type: 'time',
+          axisLine: { lineStyle: { color: gridColor } },
+          axisTick: { show: false },
+          axisLabel: {
+            color: subTextColor,
+            fontSize: 9,
+            formatter: (value: number) => {
+              const date = new Date(value);
+              return date.toLocaleDateString('en-US', { month: 'short', year: '2-digit' });
+            },
+            margin: 6,
+          },
+          splitLine: { show: false },
+        },
+        yAxis: {
+          type: 'value',
+          position: 'left',
+          axisLine: { show: false },
+          axisTick: { show: false },
+          axisLabel: {
+            color: subTextColor,
+            fontSize: 9,
+            formatter: (value: number) => `$${value.toFixed(2)}`,
+            margin: 8,
+          },
+          splitLine: { lineStyle: { color: gridColor, width: 0.5 } },
+        },
+        series: series,
+      };
+
+      return option;
+    }, [isDark]);
+
     return (
       <div className="w-full rounded-lg border !border-primary/20 overflow-hidden shadow-none">
         <Accordion type="single" collapsible defaultValue="open">
@@ -530,8 +845,891 @@ export const InteractiveStockChart = React.memo(
             ))}
           </div>
 
+          {/* Earnings Results Section */}
+          {earnings_data && earnings_data.length > 0 && (
+            <div className="mt-5 pt-4 border-t border-border/30">
+              <div className="flex items-center justify-between mb-3">
+                <div className="flex items-center gap-1.5">
+                  <Target className="size-3.5 text-primary/80" />
+                  <h3 className="text-xs font-medium text-foreground/90">Earnings Reports</h3>
+                </div>
+                
+                <div className="flex items-center gap-1 bg-muted/50 rounded-full p-0.5">
+                  <button
+                    onClick={() => setEarningsViewMode('reports')}
+                    className={cn(
+                      "flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium transition-colors",
+                      earningsViewMode === 'reports'
+                        ? "bg-background text-foreground shadow-sm"
+                        : "text-muted-foreground hover:text-foreground"
+                    )}
+                  >
+                    <List className="size-3" />
+                    Reports
+                  </button>
+                  <button
+                    onClick={() => setEarningsViewMode('chart')}
+                    className={cn(
+                      "flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium transition-colors",
+                      earningsViewMode === 'chart'
+                        ? "bg-background text-foreground shadow-sm"
+                        : "text-muted-foreground hover:text-foreground"
+                    )}
+                  >
+                    <BarChart3 className="size-3" />
+                    Chart
+                  </button>
+                </div>
+              </div>
+
+              {earningsViewMode === 'chart' && earnings_data && (
+                <>
+                  {earnings_data.map((company, companyIndex) => (
+                    <div key={company.ticker} className="bg-card/40 border border-border/30 rounded-lg p-4 mb-2">
+                      {/* Company Header */}
+                      <div className="flex items-center justify-between mb-3">
+                        <div className="flex items-center gap-2">
+                          <div className="w-2 h-2 rounded-full" style={{ backgroundColor: getSeriesColor(companyIndex).line }}></div>
+                          <span className="font-medium text-sm">{company.companyName}</span>
+                          <Badge variant="outline" className="text-xs px-1.5 py-0">{company.ticker}</Badge>
+                        </div>
+                        <Badge variant="secondary" className="text-xs">
+                          {company.earnings.length} reports
+                        </Badge>
+                      </div>
+                      
+                      {/* Individual Chart */}
+                      <div className="w-full h-48 bg-card/20 rounded-lg p-1">
+                        <ReactECharts
+                          option={createEarningsChartForCompany(company, companyIndex)}
+                          style={{ height: '100%', width: '100%' }}
+                          theme={isDark ? 'dark' : undefined}
+                          opts={{ renderer: 'canvas' }}
+                        />
+                      </div>
+                    </div>
+                  ))}
+                </>
+              )}
+
+              {earningsViewMode === 'reports' && earnings_data && (
+                <>
+                  {earnings_data.map((company, companyIndex) => {
+                    const isExpanded = expandedCompanies.has(company.ticker);
+                    return (
+                      <div key={company.ticker} className="bg-card/40 border border-border/30 rounded-lg overflow-hidden mb-2">
+                        {/* Clickable Company Header */}
+                        <button
+                          onClick={() => toggleCompanyExpansion(company.ticker)}
+                          className="w-full p-3 flex items-center justify-between hover:bg-muted/20 transition-colors"
+                        >
+                          <div className="flex items-center gap-2">
+                            <div className="w-2 h-2 rounded-full" style={{ backgroundColor: getSeriesColor(companyIndex).line }}></div>
+                            <span className="font-medium text-sm">{company.companyName}</span>
+                            <Badge variant="outline" className="text-xs px-1.5 py-0">{company.ticker}</Badge>
+                          </div>
+                          <div className="flex items-center gap-2">
+                            <Badge variant="secondary" className="text-xs">
+                              {company.earnings.length} reports
+                            </Badge>
+                            {isExpanded ? (
+                              <ChevronUp className="size-4 text-muted-foreground" />
+                            ) : (
+                              <ChevronDown className="size-4 text-muted-foreground" />
+                            )}
+                          </div>
+                        </button>
+
+                        {/* Expandable Earnings Timeline */}
+                        {isExpanded && (
+                          <div className="px-3 pb-3">
+                            <div className="grid gap-2 max-h-80 overflow-y-auto pr-2">
+                              {company.earnings.map((earning, index) => {
+                                const isPositiveSurprise = (earning.surprise_prc || 0) > 0;
+                                const hasEstimate = earning.eps_estimate !== null;
+                                
+                                return (
+                                  <div key={`${earning.date}-${index}`} className="flex items-center justify-between p-2 rounded bg-muted/30 hover:bg-muted/50 transition-colors">
+                                    <div className="flex items-center gap-3 min-w-0 flex-1">
+                                      {/* Date */}
+                                      <div className="flex items-center gap-1.5 text-xs text-muted-foreground min-w-fit">
+                                        <Calendar className="size-3" />
+                                        <span>{new Date(earning.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: '2-digit' })}</span>
+                                        <span className="text-xs opacity-70">{earning.time}</span>
+                                      </div>
+
+                                      {/* EPS Values */}
+                                      <div className="flex items-center gap-2 min-w-0">
+                                        <div className="text-xs">
+                                          <span className="text-muted-foreground">Actual:</span>
+                                          <span className="ml-1 font-medium">${earning.eps_actual?.toFixed(2) || 'N/A'}</span>
+                                        </div>
+                                        {hasEstimate && (
+                                          <div className="text-xs">
+                                            <span className="text-muted-foreground">Est:</span>
+                                            <span className="ml-1">${earning.eps_estimate?.toFixed(2) || 'N/A'}</span>
+                                          </div>
+                                        )}
+                                      </div>
+                                    </div>
+
+                                    {/* Surprise */}
+                                    {hasEstimate && earning.surprise_prc !== null && (
+                                      <div className={cn(
+                                        "flex items-center gap-1 text-xs font-medium px-2 py-1 rounded-full",
+                                        isPositiveSurprise 
+                                          ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-400"
+                                          : "bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-400"
+                                      )}>
+                                        {isPositiveSurprise ? (
+                                          <TrendingUp className="size-3" />
+                                        ) : (
+                                          <TrendingDown className="size-3" />
+                                        )}
+                                        <span>{Math.abs(earning.surprise_prc || 0).toFixed(1)}%</span>
+                                      </div>
+                                    )}
+                                  </div>
+                                );
+                              })}
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+                </>
+              )}
+            </div>
+          )}
+
+          {/* SEC Filings Section */}
+          {sec_filings && sec_filings.length > 0 && (
+            <div className="mt-5 pt-4 border-t border-border/30">
+              <div className="flex items-center justify-between mb-3">
+                <div className="flex items-center gap-1.5">
+                  <FileText className="size-3.5 text-primary/80" />
+                  <h3 className="text-xs font-medium text-foreground/90">SEC Filings</h3>
+                </div>
+              </div>
+
+              <div className="space-y-3">
+                {/* Group filings by company */}
+                {Object.entries(
+                  sec_filings?.reduce((acc, filing) => {
+                    const company = filing.metadata?.name || filing.requestedCompany;
+                    if (!acc[company]) acc[company] = [];
+                    acc[company].push(filing);
+                    return acc;
+                  }, {} as Record<string, typeof sec_filings>) || {}
+                ).map(([companyName, companyFilings], companyIndex) => {
+                  const isExpanded = !expandedCompanies.has(`sec-${companyName}`); // Inverted logic - default open
+                  return (
+                    <div key={companyName} className="bg-card/40 border border-border/30 rounded-lg overflow-hidden">
+                      {/* Clickable Company Header */}
+                      <button
+                        onClick={() => toggleCompanyExpansion(`sec-${companyName}`)}
+                        className="w-full p-4 flex items-center justify-between hover:bg-muted/20 transition-colors"
+                      >
+                        <div className="flex items-center gap-2">
+                          <Building2 className="size-4 text-muted-foreground" />
+                          <h4 className="font-medium text-sm">{companyName}</h4>
+                          <Badge variant="secondary" className="text-xs">
+                            {companyFilings?.length || 0} filing{(companyFilings?.length || 0) > 1 ? 's' : ''}
+                          </Badge>
+                        </div>
+                        {isExpanded ? (
+                          <ChevronUp className="size-4 text-muted-foreground" />
+                        ) : (
+                          <ChevronDown className="size-4 text-muted-foreground" />
+                        )}
+                      </button>
+
+                      {/* Expandable Filings Grid */}
+                      {isExpanded && (
+                        <div className="px-4 pb-4">
+                          <div className="grid gap-2 max-h-80 overflow-y-auto pr-2">
+                            {companyFilings?.map((filing, filingIndex) => (
+                        <Dialog key={`${filing.id}-${filingIndex}`}>
+                          <DialogTrigger asChild>
+                            <button className="w-full p-3 rounded-md bg-muted/30 hover:bg-muted/50 transition-colors text-left group">
+                              <div className="flex items-start justify-between gap-3">
+                                <div className="flex-1 min-w-0">
+                                  <div className="flex items-center gap-2 mb-1">
+                                    <Badge 
+                                      variant="outline" 
+                                      className={cn(
+                                        "text-xs px-1.5 py-0",
+                                        (filing.metadata?.document_type === '10-K' || filing.metadata?.form_type === '10-K') && "border-blue-500/50 text-blue-600 dark:text-blue-400",
+                                        (filing.metadata?.document_type === '10-Q' || filing.metadata?.form_type === '10-Q') && "border-emerald-500/50 text-emerald-600 dark:text-emerald-400",
+                                        (filing.metadata?.document_type === '8-K' || filing.metadata?.form_type === '8-K') && "border-orange-500/50 text-orange-600 dark:text-orange-400"
+                                      )}
+                                    >
+                                      {filing.metadata?.document_type || filing.metadata?.form_type || filing.requestedFilingType}
+                                    </Badge>
+                                    {getFilingDate(filing.metadata) && (
+                                      <span className="text-xs text-muted-foreground">
+                                        {parseSecFilingDate(getFilingDate(filing.metadata)!).toLocaleDateString('en-US', {
+                                          month: 'short',
+                                          day: 'numeric',
+                                          year: 'numeric'
+                                        })}
+                                      </span>
+                                    )}
+                                  </div>
+                                  <h5 className="text-sm font-medium line-clamp-1 group-hover:text-primary transition-colors">
+                                    {filing.title}
+                                  </h5>
+                                  {filing.metadata?.ticker && (
+                                    <p className="text-xs text-muted-foreground mt-1">
+                                      Ticker: {filing.metadata.ticker}
+                                    </p>
+                                  )}
+                                  {(filing.metadata?.part || filing.metadata?.item) && (
+                                    <p className="text-xs text-muted-foreground mt-1">
+                                      {filing.metadata.part && `Part ${filing.metadata.part}`}
+                                      {filing.metadata.part && filing.metadata.item && ', '}
+                                      {filing.metadata.item && `Item ${filing.metadata.item}`}
+                                    </p>
+                                  )}
+                                </div>
+                                <ExternalLink className="size-4 text-muted-foreground group-hover:text-primary transition-colors shrink-0 mt-1" />
+                              </div>
+                            </button>
+                          </DialogTrigger>
+                          
+                          <DialogContent className="max-w-[98vw] max-h-[90vh] w-[70vw] overflow-hidden !max-w-none">
+                            <DialogHeader>
+                              <DialogTitle className="flex items-center gap-3">
+                                <FileText className="size-5" />
+                                <span>{filing.title}</span>
+                              </DialogTitle>
+                            </DialogHeader>
+                            
+                            <div className="flex items-center gap-4 text-sm text-muted-foreground pb-3 border-b">
+                              {(filing.metadata?.document_type || filing.metadata?.form_type) && (
+                                <Badge 
+                                  variant="outline" 
+                                  className={cn(
+                                    "text-xs",
+                                    (filing.metadata?.document_type === '10-K' || filing.metadata?.form_type === '10-K') && "border-blue-500/50 text-blue-600 dark:text-blue-400",
+                                    (filing.metadata?.document_type === '10-Q' || filing.metadata?.form_type === '10-Q') && "border-emerald-500/50 text-emerald-600 dark:text-emerald-400",
+                                    (filing.metadata?.document_type === '8-K' || filing.metadata?.form_type === '8-K') && "border-orange-500/50 text-orange-600 dark:text-orange-400"
+                                  )}
+                                >
+                                  {filing.metadata?.document_type || filing.metadata?.form_type}
+                                </Badge>
+                              )}
+                              {getFilingDate(filing.metadata) && (
+                                <span className="text-xs">
+                                  Filed: {parseSecFilingDate(getFilingDate(filing.metadata)!).toLocaleDateString('en-US', {
+                                    month: 'long',
+                                    day: 'numeric',
+                                    year: 'numeric'
+                                  })}
+                                </span>
+                              )}
+                              {filing.metadata?.accession_number && (
+                                <span className="text-xs">
+                                  Accession: {filing.metadata.accession_number}
+                                </span>
+                              )}
+                              {(filing.metadata?.part || filing.metadata?.item) && (
+                                <span className="text-xs">
+                                  {filing.metadata.part && `Part ${filing.metadata.part}`}
+                                  {filing.metadata.part && filing.metadata.item && ', '}
+                                  {filing.metadata.item && `Item ${filing.metadata.item}`}
+                                </span>
+                              )}
+                            </div>
+                            
+                            <ScrollArea className="h-[calc(90vh-200px)] w-full">
+                              <div className="w-full p-4 overflow-x-auto">
+                                <div className="prose prose-sm dark:prose-invert !max-w-none w-full
+                                               prose-table:min-w-full prose-table:w-auto prose-table:table prose-table:whitespace-nowrap
+                                               prose-pre:overflow-x-auto prose-pre:whitespace-pre-wrap prose-pre:break-all
+                                               prose-p:break-words prose-h1:break-words prose-h2:break-words prose-h3:break-words
+                                               prose-h4:break-words prose-h5:break-words prose-h6:break-words
+                                               [&_table]:min-w-full [&_table]:w-auto [&_table]:table [&_table]:border-collapse
+                                               [&_td]:px-2 [&_td]:py-1 [&_td]:border [&_td]:border-border/30
+                                               [&_th]:px-2 [&_th]:py-1 [&_th]:border [&_th]:border-border/30 [&_th]:bg-muted/30">
+                                  <MarkdownRenderer content={filing.content} />
+                                </div>
+                              </div>
+                            </ScrollArea>
+                          </DialogContent>
+                        </Dialog>
+                            ))}
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+
+
+          {/* Company Statistics Section - simplified neutral cards */}
+          {company_statistics && Object.keys(company_statistics).length > 0 && (
+            <div className="mt-5 pt-4 border-t border-border/30">
+              <div className="flex items-center gap-1.5 mb-2">
+                <Activity className="size-3.5 text-muted-foreground" />
+                <h3 className="text-xs font-medium text-foreground/90">Key Metrics</h3>
+              </div>
+              <div className="space-y-2">
+                {Object.entries(company_statistics).map(([company, stats]: [string, any]) => (
+                  <div key={company} className="bg-card/40 border border-border/30 rounded-lg p-3">
+                    <div className="flex items-center justify-between mb-2">
+                      <div className="flex items-center gap-2">
+                        <Building2 className="size-4 text-muted-foreground" />
+                        <h4 className="font-medium text-sm">{company}</h4>
+                      </div>
+                    </div>
+                    <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
+                      <div className="flex items-center justify-between text-xs">
+                        <span className="text-muted-foreground">Market Cap</span>
+                        <span className="font-medium">${(stats.valuations_metrics?.market_capitalization / 1e9).toFixed(2)}B</span>
+                      </div>
+                      <div className="flex items-center justify-between text-xs">
+                        <span className="text-muted-foreground">P/E</span>
+                        <span className="font-medium">{stats.valuations_metrics?.trailing_pe?.toFixed(2) || 'N/A'}</span>
+                      </div>
+                      <div className="flex items-center justify-between text-xs">
+                        <span className="text-muted-foreground">P/B</span>
+                        <span className="font-medium">{stats.valuations_metrics?.price_to_book_mrq?.toFixed(2) || 'N/A'}</span>
+                      </div>
+                      <div className="flex items-center justify-between text-xs">
+                        <span className="text-muted-foreground">Revenue (TTM)</span>
+                        <span className="font-medium">${(stats.financials?.income_statement?.revenue_ttm / 1e9).toFixed(2)}B</span>
+                      </div>
+                      <div className="flex items-center justify-between text-xs">
+                        <span className="text-muted-foreground">Profit Margin</span>
+                        <span className="font-medium">{(stats.financials?.profit_margin * 100).toFixed(1)}%</span>
+                      </div>
+                      <div className="flex items-center justify-between text-xs">
+                        <span className="text-muted-foreground">ROE</span>
+                        <span className="font-medium">{(stats.financials?.return_on_equity_ttm * 100).toFixed(1)}%</span>
+                      </div>
+                      <div className="flex items-center justify-between text-xs">
+                        <span className="text-muted-foreground">52W Range</span>
+                        <span className="font-medium">${stats.stock_price_summary?.fifty_two_week_low} - ${stats.stock_price_summary?.fifty_two_week_high}</span>
+                      </div>
+                      <div className="flex items-center justify-between text-xs">
+                        <span className="text-muted-foreground">Beta</span>
+                        <span className="font-medium">{stats.stock_price_summary?.beta?.toFixed(2) || 'N/A'}</span>
+                      </div>
+                      <div className="flex items-center justify-between text-xs">
+                        <span className="text-muted-foreground">Div. Yield</span>
+                        <span className="font-medium">{stats.dividends_and_splits?.forward_annual_dividend_yield ? (stats.dividends_and_splits.forward_annual_dividend_yield * 100).toFixed(2) + '%' : 'N/A'}</span>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Financial Statements Section */}
+          {(balance_sheets && Object.keys(balance_sheets).length > 0) || 
+           (income_statements && Object.keys(income_statements).length > 0) || 
+           (cash_flows && Object.keys(cash_flows).length > 0) ? (() => {
+             const hasIncome = !!(income_statements && Object.keys(income_statements).length > 0);
+             const hasBalance = !!(balance_sheets && Object.keys(balance_sheets).length > 0);
+             const hasCash = !!(cash_flows && Object.keys(cash_flows).length > 0);
+             
+             const availableTabs = [];
+             if (hasIncome) availableTabs.push('income');
+             if (hasBalance) availableTabs.push('balance');
+             if (hasCash) availableTabs.push('cash');
+             
+             const defaultTab = availableTabs[0] || 'income';
+             const gridCols = availableTabs.length === 1 ? 'grid-cols-1' : 
+                            availableTabs.length === 2 ? 'grid-cols-2' : 'grid-cols-3';
+             
+             return (
+            <div className="mt-5 pt-4 border-t border-border/30">
+              <div className="flex items-center justify-between mb-3">
+                <div className="flex items-center gap-1.5">
+                  <Wallet className="size-3.5 text-primary/80" />
+                  <h3 className="text-xs font-medium text-foreground/90">
+                    {availableTabs.length === 1 ? 
+                      (hasIncome ? 'Income Statement' : hasBalance ? 'Balance Sheet' : 'Cash Flow Statement') : 
+                      'Financial Statements'
+                    }
+                  </h3>
+                </div>
+              </div>
+
+              {availableTabs.length > 1 ? (
+                <Tabs defaultValue={defaultTab} className="w-full">
+                  <TabsList className={`grid w-full ${gridCols} mb-3`}>
+                    {hasIncome && <TabsTrigger value="income" className="text-xs">Income Statement</TabsTrigger>}
+                    {hasBalance && <TabsTrigger value="balance" className="text-xs">Balance Sheet</TabsTrigger>}
+                    {hasCash && <TabsTrigger value="cash" className="text-xs">Cash Flow</TabsTrigger>}
+                  </TabsList>
+
+                {/* Income Statement Tab */}
+                <TabsContent value="income" className="space-y-3">
+                  {income_statements && Object.entries(income_statements).map(([company, statements]: [string, any[]]) => (
+                    <div key={company} className="bg-card/40 border border-border/30 rounded-lg p-4">
+                      <div className="flex items-center gap-2 mb-3">
+                        <Building2 className="size-4 text-muted-foreground" />
+                        <h4 className="font-medium text-sm">{company}</h4>
+                      </div>
+                      
+                      <div className="overflow-x-auto">
+                        <table className="w-full text-xs">
+                          <thead>
+                            <tr className="border-b border-border/30">
+                              <th className="text-left py-2 pr-2 text-muted-foreground font-medium">Period</th>
+                              <th className="text-right px-2 text-muted-foreground font-medium">Revenue</th>
+                              <th className="text-right px-2 text-muted-foreground font-medium">Gross Profit</th>
+                              <th className="text-right px-2 text-muted-foreground font-medium">Operating Income</th>
+                              <th className="text-right px-2 text-muted-foreground font-medium">Net Income</th>
+                              <th className="text-right pl-2 text-muted-foreground font-medium">EPS</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {statements.slice(0, 5).map((stmt, idx) => (
+                              <tr key={idx} className="border-b border-border/20">
+                                <td className="py-2 pr-2">{new Date(stmt.fiscal_date).toLocaleDateString('en-US', { month: 'short', year: 'numeric' })}</td>
+                                <td className="text-right px-2 font-medium">${(stmt.sales / 1e9).toFixed(2)}B</td>
+                                <td className="text-right px-2">${(stmt.gross_profit / 1e9).toFixed(2)}B</td>
+                                <td className="text-right px-2">${(stmt.operating_income / 1e9).toFixed(2)}B</td>
+                                <td className="text-right px-2 font-medium">${(stmt.net_income / 1e9).toFixed(2)}B</td>
+                                <td className="text-right pl-2">${stmt.eps_diluted?.toFixed(2) || 'N/A'}</td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </div>
+                    </div>
+                  ))}
+                </TabsContent>
+
+                {/* Balance Sheet Tab */}
+                <TabsContent value="balance" className="space-y-3">
+                  {balance_sheets && Object.entries(balance_sheets).map(([company, sheets]: [string, any[]]) => (
+                    <div key={company} className="bg-card/40 border border-border/30 rounded-lg p-4">
+                      <div className="flex items-center gap-2 mb-3">
+                        <Building2 className="size-4 text-muted-foreground" />
+                        <h4 className="font-medium text-sm">{company}</h4>
+                      </div>
+                      
+                      <div className="overflow-x-auto">
+                        <table className="w-full text-xs">
+                          <thead>
+                            <tr className="border-b border-border/30">
+                              <th className="text-left py-2 pr-2 text-muted-foreground font-medium">Period</th>
+                              <th className="text-right px-2 text-muted-foreground font-medium">Total Assets</th>
+                              <th className="text-right px-2 text-muted-foreground font-medium">Total Liabilities</th>
+                              <th className="text-right px-2 text-muted-foreground font-medium">Shareholders Equity</th>
+                              <th className="text-right px-2 text-muted-foreground font-medium">Cash</th>
+                              <th className="text-right pl-2 text-muted-foreground font-medium">Debt/Equity</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {sheets.slice(0, 5).map((sheet, idx) => (
+                              <tr key={idx} className="border-b border-border/20">
+                                <td className="py-2 pr-2">{sheet.year}</td>
+                                <td className="text-right px-2 font-medium">${(sheet.assets.total_assets / 1e9).toFixed(2)}B</td>
+                                <td className="text-right px-2">${(sheet.liabilities.total_liabilities / 1e9).toFixed(2)}B</td>
+                                <td className="text-right px-2">${(sheet.shareholders_equity.total_shareholders_equity / 1e9).toFixed(2)}B</td>
+                                <td className="text-right px-2">${(sheet.assets.current_assets.cash_and_cash_equivalents / 1e9).toFixed(2)}B</td>
+                                <td className="text-right pl-2">{((sheet.liabilities.non_current_liabilities.long_term_debt / sheet.shareholders_equity.total_shareholders_equity) * 100).toFixed(1)}%</td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </div>
+                    </div>
+                  ))}
+                </TabsContent>
+
+                {/* Cash Flow Tab */}
+                <TabsContent value="cash" className="space-y-3">
+                  {cash_flows && Object.entries(cash_flows).map(([company, flows]: [string, any[]]) => (
+                    <div key={company} className="bg-card/40 border border-border/30 rounded-lg p-4">
+                      <div className="flex items-center gap-2 mb-3">
+                        <Building2 className="size-4 text-muted-foreground" />
+                        <h4 className="font-medium text-sm">{company}</h4>
+                      </div>
+                      
+                      <div className="overflow-x-auto">
+                        <table className="w-full text-xs">
+                          <thead>
+                            <tr className="border-b border-border/30">
+                              <th className="text-left py-2 pr-2 text-muted-foreground font-medium">Period</th>
+                              <th className="text-right px-2 text-muted-foreground font-medium">Operating CF</th>
+                              <th className="text-right px-2 text-muted-foreground font-medium">Investing CF</th>
+                              <th className="text-right px-2 text-muted-foreground font-medium">Financing CF</th>
+                              <th className="text-right px-2 text-muted-foreground font-medium">Free Cash Flow</th>
+                              <th className="text-right pl-2 text-muted-foreground font-medium">Cash End</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {flows.slice(0, 5).map((flow, idx) => (
+                              <tr key={idx} className="border-b border-border/20">
+                                <td className="py-2 pr-2">{flow.year}</td>
+                                <td className="text-right px-2 font-medium">${(flow.operating_activities.operating_cash_flow / 1e9).toFixed(2)}B</td>
+                                <td className="text-right px-2">${(flow.investing_activities.investing_cash_flow / 1e9).toFixed(2)}B</td>
+                                <td className="text-right px-2">${(flow.financing_activities.financing_cash_flow / 1e9).toFixed(2)}B</td>
+                                <td className="text-right px-2 font-medium">${(flow.free_cash_flow / 1e9).toFixed(2)}B</td>
+                                <td className="text-right pl-2">${(flow.end_cash_position / 1e9).toFixed(2)}B</td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </div>
+                    </div>
+                  ))}
+                </TabsContent>
+              </Tabs>
+              ) : (
+                // Single statement - show directly without tabs
+                <div className="space-y-3">
+                  {hasIncome && income_statements && Object.entries(income_statements).map(([company, statements]: [string, any[]]) => (
+                    <div key={company} className="bg-card/40 border border-border/30 rounded-lg p-4">
+                      <div className="flex items-center gap-2 mb-3">
+                        <Building2 className="size-4 text-muted-foreground" />
+                        <h4 className="font-medium text-sm">{company}</h4>
+                      </div>
+                      
+                      <div className="overflow-x-auto">
+                        <table className="w-full text-xs">
+                          <thead>
+                            <tr className="border-b border-border/30">
+                              <th className="text-left py-2 pr-2 text-muted-foreground font-medium">Period</th>
+                              <th className="text-right px-2 text-muted-foreground font-medium">Revenue</th>
+                              <th className="text-right px-2 text-muted-foreground font-medium">Gross Profit</th>
+                              <th className="text-right px-2 text-muted-foreground font-medium">Operating Income</th>
+                              <th className="text-right px-2 text-muted-foreground font-medium">Net Income</th>
+                              <th className="text-right pl-2 text-muted-foreground font-medium">EPS</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {statements.slice(0, 5).map((stmt, idx) => (
+                              <tr key={idx} className="border-b border-border/20">
+                                <td className="py-2 pr-2">{new Date(stmt.fiscal_date).toLocaleDateString('en-US', { month: 'short', year: 'numeric' })}</td>
+                                <td className="text-right px-2 font-medium">${(stmt.sales / 1e9).toFixed(2)}B</td>
+                                <td className="text-right px-2">${(stmt.gross_profit / 1e9).toFixed(2)}B</td>
+                                <td className="text-right px-2">${(stmt.operating_income / 1e9).toFixed(2)}B</td>
+                                <td className="text-right px-2 font-medium">${(stmt.net_income / 1e9).toFixed(2)}B</td>
+                                <td className="text-right pl-2">${stmt.eps_diluted?.toFixed(2) || 'N/A'}</td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </div>
+                    </div>
+                  ))}
+                  
+                  {hasBalance && balance_sheets && Object.entries(balance_sheets).map(([company, sheets]: [string, any[]]) => (
+                    <div key={company} className="bg-card/40 border border-border/30 rounded-lg p-4">
+                      <div className="flex items-center gap-2 mb-3">
+                        <Building2 className="size-4 text-muted-foreground" />
+                        <h4 className="font-medium text-sm">{company}</h4>
+                      </div>
+                      
+                      <div className="overflow-x-auto">
+                        <table className="w-full text-xs">
+                          <thead>
+                            <tr className="border-b border-border/30">
+                              <th className="text-left py-2 pr-2 text-muted-foreground font-medium">Period</th>
+                              <th className="text-right px-2 text-muted-foreground font-medium">Total Assets</th>
+                              <th className="text-right px-2 text-muted-foreground font-medium">Total Liabilities</th>
+                              <th className="text-right px-2 text-muted-foreground font-medium">Shareholders Equity</th>
+                              <th className="text-right px-2 text-muted-foreground font-medium">Cash</th>
+                              <th className="text-right pl-2 text-muted-foreground font-medium">Debt/Equity</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {sheets.slice(0, 5).map((sheet, idx) => (
+                              <tr key={idx} className="border-b border-border/20">
+                                <td className="py-2 pr-2">{sheet.year}</td>
+                                <td className="text-right px-2 font-medium">${(sheet.assets.total_assets / 1e9).toFixed(2)}B</td>
+                                <td className="text-right px-2">${(sheet.liabilities.total_liabilities / 1e9).toFixed(2)}B</td>
+                                <td className="text-right px-2">${(sheet.shareholders_equity.total_shareholders_equity / 1e9).toFixed(2)}B</td>
+                                <td className="text-right px-2">${(sheet.assets.current_assets.cash_and_cash_equivalents / 1e9).toFixed(2)}B</td>
+                                <td className="text-right pl-2">{((sheet.liabilities.non_current_liabilities.long_term_debt / sheet.shareholders_equity.total_shareholders_equity) * 100).toFixed(1)}%</td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </div>
+                    </div>
+                  ))}
+                  
+                  {hasCash && cash_flows && Object.entries(cash_flows).map(([company, flows]: [string, any[]]) => (
+                    <div key={company} className="bg-card/40 border border-border/30 rounded-lg p-4">
+                      <div className="flex items-center gap-2 mb-3">
+                        <Building2 className="size-4 text-muted-foreground" />
+                        <h4 className="font-medium text-sm">{company}</h4>
+                      </div>
+                      
+                      <div className="overflow-x-auto">
+                        <table className="w-full text-xs">
+                          <thead>
+                            <tr className="border-b border-border/30">
+                              <th className="text-left py-2 pr-2 text-muted-foreground font-medium">Period</th>
+                              <th className="text-right px-2 text-muted-foreground font-medium">Operating CF</th>
+                              <th className="text-right px-2 text-muted-foreground font-medium">Investing CF</th>
+                              <th className="text-right px-2 text-muted-foreground font-medium">Financing CF</th>
+                              <th className="text-right px-2 text-muted-foreground font-medium">Free Cash Flow</th>
+                              <th className="text-right pl-2 text-muted-foreground font-medium">Cash End</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {flows.slice(0, 5).map((flow, idx) => (
+                              <tr key={idx} className="border-b border-border/20">
+                                <td className="py-2 pr-2">{flow.year}</td>
+                                <td className="text-right px-2 font-medium">${(flow.operating_activities.operating_cash_flow / 1e9).toFixed(2)}B</td>
+                                <td className="text-right px-2">${(flow.investing_activities.investing_cash_flow / 1e9).toFixed(2)}B</td>
+                                <td className="text-right px-2">${(flow.financing_activities.financing_cash_flow / 1e9).toFixed(2)}B</td>
+                                <td className="text-right px-2 font-medium">${(flow.free_cash_flow / 1e9).toFixed(2)}B</td>
+                                <td className="text-right pl-2">${(flow.end_cash_position / 1e9).toFixed(2)}B</td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+             );
+           })() : null}
+
+          {/* Dividends - full width */}
+          {dividends_data && Object.keys(dividends_data).length > 0 && (() => {
+            // Check if there are any valid dividends after deduplication
+            const hasValidDividends = Object.entries(dividends_data).some(([company, dividends]: [string, any[]]) => {
+              const uniqueDividends = dividends.reduce((acc: any[], current: any) => {
+                const key = `${current.ex_date}-${current.amount}`;
+                if (!acc.some((item: any) => `${item.ex_date}-${item.amount}` === key)) {
+                  acc.push(current);
+                }
+                return acc;
+              }, [] as any[]);
+              return uniqueDividends.length > 0;
+            });
+            
+            return hasValidDividends;
+          })() && (
+            <div className="mt-5 pt-4 border-t border-border/30">
+              <div className="grid grid-cols-1 gap-4">
+                <div className="col-span-full">
+                    <div className="flex items-center gap-1.5 mb-2">
+                      <Banknote className="size-3.5 text-muted-foreground" />
+                      <h3 className="text-xs font-medium text-foreground/90">Dividends</h3>
+                    </div>
+                    <div className="space-y-2">
+                      {Object.entries(dividends_data).map(([company, dividends]: [string, any[]]) => {
+                        // Remove duplicates based on ex_date and amount
+                        const uniqueDividends = dividends.reduce((acc: any[], current: any) => {
+                          const key = `${current.ex_date}-${current.amount}`;
+                          if (!acc.some((item: any) => `${item.ex_date}-${item.amount}` === key)) {
+                            acc.push(current);
+                          }
+                          return acc;
+                        }, [] as any[]);
+                        
+                        // Skip if no dividends after deduplication
+                        if (uniqueDividends.length === 0) {
+                          return null;
+                        }
+                        
+                        // Calculate dividend metrics
+                        const sortedDividends = [...uniqueDividends].sort((a, b) => new Date(a.ex_date).getTime() - new Date(b.ex_date).getTime());
+                        const latestDividend = sortedDividends[sortedDividends.length - 1];
+                        const yearAgo = sortedDividends[sortedDividends.length - 5] || sortedDividends[0];
+                        const growthRate = (yearAgo && latestDividend) ? ((latestDividend.amount - yearAgo.amount) / yearAgo.amount * 100) : 0;
+                        
+                        // Annual dividend calculation
+                        const currentYear = new Date().getFullYear();
+                        const currentYearDividends = uniqueDividends.filter((d: any) => new Date(d.ex_date).getFullYear() === currentYear);
+                        const annualDividend = currentYearDividends.reduce((sum: number, d: any) => sum + d.amount, 0);
+                        
+                        // Prepare chart data (last 20 payments for better visualization)
+                        const chartData = sortedDividends.slice(-20).map(d => ({
+                          date: new Date(d.ex_date).getTime(),
+                          amount: d.amount,
+                          year: new Date(d.ex_date).getFullYear()
+                        }));
+
+                        const dividendChartOptions: EChartsOption = {
+                          grid: { left: 10, right: 10, top: 10, bottom: 20, containLabel: true },
+                          xAxis: {
+                            type: 'time',
+                            axisLine: { show: false },
+                            axisTick: { show: false },
+                            axisLabel: { 
+                              fontSize: 10, 
+                              color: isDark ? '#8a8a8a' : '#666',
+                              formatter: (value: any) => new Date(value).getFullYear().toString(),
+                              margin: 6
+                            },
+                            splitLine: { show: false }
+                          },
+                          yAxis: {
+                            type: 'value',
+                            axisLine: { show: false },
+                            axisTick: { show: false },
+                            axisLabel: { 
+                              fontSize: 10, 
+                              color: isDark ? '#8a8a8a' : '#666',
+                              formatter: (value: number) => `$${value.toFixed(2)}`
+                            },
+                            splitLine: { lineStyle: { color: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)' } }
+                          },
+                          tooltip: {
+                            trigger: 'axis',
+                            backgroundColor: isDark ? 'rgba(32,32,36,0.85)' : 'rgba(255,255,255,0.9)',
+                            borderColor: isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.08)',
+                            textStyle: { color: isDark ? '#fff' : '#000', fontSize: 12 },
+                            formatter: (params: any) => {
+                              const point = params[0];
+                              return `
+                                <div style="font-size: 12px;">
+                                  <div style="font-weight: 600; margin-bottom: 4px;">${new Date(point.value[0]).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}</div>
+                                  <div style="color: #10b981;">Dividend: $${point.value[1].toFixed(2)}</div>
+                                </div>
+                              `;
+                            }
+                          },
+                          series: [{
+                            type: 'line',
+                            data: chartData.map(d => [d.date, d.amount]),
+                            lineStyle: { color: isDark ? '#22c55e' : '#16a34a', width: 1.5 },
+                            itemStyle: { color: isDark ? '#22c55e' : '#16a34a' },
+                            areaStyle: { 
+                              color: {
+                                type: 'linear',
+                                x: 0, y: 0, x2: 0, y2: 1,
+                                colorStops: [
+                                  { offset: 0, color: isDark ? 'rgba(34, 197, 94, 0.18)' : 'rgba(16, 163, 74, 0.18)' },
+                                  { offset: 1, color: 'rgba(0,0,0,0)' }
+                                ]
+                              }
+                            },
+                            smooth: true,
+                            showSymbol: false
+                          }]
+                        };
+
+                        const isExpanded = expandedDividendCompanies.has(company);
+                        return (
+                          <div key={company} className="bg-card/40 border border-border/30 rounded-lg">
+                            <button onClick={() => toggleDividendExpansion(company)} className="w-full p-3 flex items-center justify-between hover:bg-muted/20 transition-colors">
+                              <div className="flex items-center gap-2">
+                                <Banknote className="size-3.5 text-muted-foreground" />
+                                <span className="font-medium text-sm">{company}</span>
+                                {latestDividend && <Badge variant="outline" className="text-[10px] px-1.5 py-0">Latest: ${latestDividend.amount.toFixed(2)}</Badge>}
+                                <Badge variant="secondary" className="text-[10px] px-1.5 py-0">Annual: ${annualDividend.toFixed(2)}</Badge>
+                                <Badge variant="secondary" className="text-[10px] px-1.5 py-0">{growthRate >= 0 ? '+' : ''}{growthRate.toFixed(1)}%</Badge>
+                              </div>
+                              {isExpanded ? <ChevronUp className="size-4 text-muted-foreground" /> : <ChevronDown className="size-4 text-muted-foreground" />}
+                            </button>
+                            {isExpanded && (
+                              <div className="px-3 pb-3">
+                                <div className="w-full h-44 bg-card/20 rounded-md p-1">
+                                  <ReactECharts option={dividendChartOptions} style={{ height: '100%', width: '100%' }} />
+                                </div>
+                                <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 mt-2 max-h-40 overflow-y-auto pr-1">
+                                  {sortedDividends.slice(-10).reverse().map((div, idx) => (
+                                    <div key={idx} className="flex items-center justify-between py-2 px-3 rounded-md bg-muted/30">
+                                      <span className="text-xs text-muted-foreground">
+                                        {new Date(div.ex_date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+                                      </span>
+                                      <span className="text-xs font-medium">${div.amount.toFixed(2)}</span>
+                                    </div>
+                                  ))}
+                                </div>
+                              </div>
+                            )}
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                </div>
+              </div>
+          )}
+
+          {/* Insider Transactions - full width showing all data */}
+          {insider_transactions && Object.keys(insider_transactions).length > 0 && (
+            <div className="mt-5 pt-4 border-t border-border/30">
+              <div className="grid grid-cols-1 gap-4">
+                <div className="col-span-full">
+                    <div className="flex items-center gap-1.5 mb-2">
+                      <UserCheck className="size-3.5 text-muted-foreground" />
+                      <h3 className="text-xs font-medium text-foreground/90">Insider Transactions</h3>
+                    </div>
+                    <div className="space-y-2">
+                      {Object.entries(insider_transactions).map(([company, transactions]: [string, any[]]) => (
+                        <div key={company} className="bg-card/40 border border-border/30 rounded-lg p-3">
+                          <div className="flex items-center gap-2 mb-2">
+                            <Building2 className="size-4 text-muted-foreground" />
+                            <h4 className="font-medium text-sm">{company}</h4>
+                            <span className="text-xs text-muted-foreground">({transactions.length} transactions)</span>
+                          </div>
+                          <div className="space-y-2 max-h-64 overflow-y-auto pr-1">
+                            {transactions.map((trans, idx) => {
+                              // Extract transaction type from description
+                              const isBuy = trans.description.toLowerCase().includes('purchase') || 
+                                           trans.description.toLowerCase().includes('stock award') ||
+                                           trans.description.toLowerCase().includes('conversion');
+                              const transType = trans.description.toLowerCase().includes('sale') ? 'Sale' : 
+                                              trans.description.toLowerCase().includes('purchase') ? 'Buy' :
+                                              trans.description.toLowerCase().includes('stock award') ? 'Grant' :
+                                              trans.description.toLowerCase().includes('conversion') ? 'Exercise' :
+                                              trans.description.toLowerCase().includes('gift') ? 'Gift' : 'Other';
+                              
+                              // Extract price from description if available
+                              const priceMatch = trans.description.match(/price (\d+\.?\d*)/);
+                              const price = priceMatch ? parseFloat(priceMatch[1]) : null;
+                              
+                              return (
+                                <div key={idx} className="flex items-start justify-between p-2 rounded-md bg-muted/30">
+                                  <div className="min-w-0">
+                                    <div className="flex items-center gap-2">
+                                      <h5 className="font-medium text-xs text-foreground truncate max-w-[200px]">{trans.full_name}</h5>
+                                      <Badge variant={isBuy ? 'default' : 'secondary'} className="text-[10px] px-1.5 py-0">
+                                        {transType}
+                                      </Badge>
+                                    </div>
+                                    <p className="text-[10px] text-muted-foreground">{trans.position}</p>
+                                    <div className="flex items-center gap-3 text-[10px] mt-1 text-muted-foreground">
+                                      <span>{trans.shares.toLocaleString()} shares</span>
+                                      {price && price > 0 && <span>@ ${price.toFixed(2)}</span>}
+                                    </div>
+                                  </div>
+                                  <div className="text-right shrink-0">
+                                    <div className="text-[10px] text-muted-foreground">
+                                      {new Date(trans.date_reported).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+                                    </div>
+                                    <div className="text-xs font-medium">
+                                      {trans.value > 0 ? `$${(trans.value / 1e6).toFixed(2)}M` : 'Grant'}
+                                    </div>
+                                  </div>
+                                </div>
+                              );
+                            })}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </div>
+          )}
+
           {/* News Results Section */}
-          {news_results && news_results.length > 0 && news_results.some((group) => group.results.length > 0) && (
+          {news_results && news_results.some((group) => group.topic !== 'financial' && group.results.length > 0) && (
             <div className="mt-5 pt-4 border-t border-border/30">
               <div className="flex items-center justify-between mb-2.5">
                 <div className="flex items-center gap-1.5">
@@ -541,67 +1739,69 @@ export const InteractiveStockChart = React.memo(
               </div>
 
               <div className="flex overflow-x-auto gap-1.5 no-scrollbar pb-1 snap-x snap-mandatory">
-                {news_results.flatMap((group, groupIndex) =>
-                  group.results.slice(0, 8).map((news, newsIndex) => (
-                    <a
-                      key={`${groupIndex}-${newsIndex}`}
-                      href={news.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="min-w-64 max-w-72 w-[calc(100vw-2.5rem)] sm:w-64 shrink-0 p-2 rounded-md bg-card/40 border border-border/30 hover:bg-card/70 transition-colors snap-start"
-                    >
-                      <div className="flex items-start gap-1.5">
-                        <div className="flex-1 min-w-0">
-                          <div className="flex items-center gap-1.5 mb-1">
-                            <Badge
-                              variant="secondary"
-                              className={cn(
-                                'rounded-full px-1.5 py-0 text-[9px] font-medium',
-                                group.topic === 'finance'
-                                  ? 'bg-emerald-100/70 text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-400'
-                                  : 'bg-blue-100/70 text-blue-700 dark:bg-blue-500/10 dark:text-blue-400',
-                              )}
-                            >
-                              {group.topic === 'finance' ? 'Finance' : 'News'}
-                            </Badge>
-                            <span className="text-[9px] text-muted-foreground/80 truncate">{group.query}</span>
-                          </div>
-                          <h4 className="text-xs font-medium line-clamp-2">{news.title}</h4>
-
-                          <p className="text-[10px] text-muted-foreground line-clamp-2 mt-1">{news.content}</p>
-
-                          <div className="flex items-center justify-between mt-1.5">
-                            <div className="flex items-center gap-1">
-                              <div className="relative w-3 h-3 rounded-sm bg-muted/50 flex items-center justify-center overflow-hidden">
-                                <img
-                                  src={`https://www.google.com/s2/favicons?sz=128&domain=${new URL(news.url).hostname}`}
-                                  alt=""
-                                  className="w-3 h-3 object-contain"
-                                  onError={(e) => {
-                                    e.currentTarget.src =
-                                      "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'/%3E%3Cline x1='12' y1='8' x2='12' y2='16'/%3E%3Cline x1='8' y1='12' x2='16' y2='12'/%3E%3C/svg%3E";
-                                  }}
-                                />
-                              </div>
-                              <span className="text-[9px] text-muted-foreground/80 truncate max-w-[100px]">
-                                {new URL(news.url).hostname.replace('www.', '')}
-                              </span>
+                {news_results
+                  .filter((group) => group.topic !== 'financial')
+                  .flatMap((group, groupIndex) =>
+                    group.results.slice(0, 8).map((news, newsIndex) => (
+                      <a
+                        key={`${groupIndex}-${newsIndex}`}
+                        href={news.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="min-w-64 max-w-72 w-[calc(100vw-2.5rem)] sm:w-64 shrink-0 p-2 rounded-md bg-card/40 border border-border/30 hover:bg-card/70 transition-colors snap-start"
+                      >
+                        <div className="flex items-start gap-1.5">
+                          <div className="flex-1 min-w-0">
+                            <div className="flex items-center gap-1.5 mb-1">
+                              <Badge
+                                variant="secondary"
+                                className={cn(
+                                  'rounded-full px-1.5 py-0 text-[9px] font-medium',
+                                  group.topic === 'finance'
+                                    ? 'bg-emerald-100/70 text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-400'
+                                    : 'bg-blue-100/70 text-blue-700 dark:bg-blue-500/10 dark:text-blue-400',
+                                )}
+                              >
+                                {group.topic === 'finance' ? 'Finance' : 'News'}
+                              </Badge>
+                              <span className="text-[9px] text-muted-foreground/80 truncate">{group.query}</span>
                             </div>
+                            <h4 className="text-xs font-medium line-clamp-2">{news.title}</h4>
 
-                            {news.published_date && (
-                              <time className="text-[9px] text-muted-foreground/70">
-                                {new Date(news.published_date).toLocaleDateString(undefined, {
-                                  month: 'short',
-                                  day: 'numeric',
-                                })}
-                              </time>
-                            )}
+                            <p className="text-[10px] text-muted-foreground line-clamp-2 mt-1">{news.content}</p>
+
+                            <div className="flex items-center justify-between mt-1.5">
+                              <div className="flex items-center gap-1">
+                                <div className="relative w-3 h-3 rounded-sm bg-muted/50 flex items-center justify-center overflow-hidden">
+                                  <img
+                                    src={`https://www.google.com/s2/favicons?sz=128&domain=${new URL(news.url).hostname}`}
+                                    alt=""
+                                    className="w-3 h-3 object-contain"
+                                    onError={(e) => {
+                                      e.currentTarget.src =
+                                        "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'/%3E%3Cline x1='12' y1='8' x2='12' y2='16'/%3E%3Cline x1='8' y1='12' x2='16' y2='12'/%3E%3C/svg%3E";
+                                    }}
+                                  />
+                                </div>
+                                <span className="text-[9px] text-muted-foreground/80 truncate max-w-[100px]">
+                                  {new URL(news.url).hostname.replace('www.', '')}
+                                </span>
+                              </div>
+
+                              {news.published_date && (
+                                <time className="text-[9px] text-muted-foreground/70">
+                                  {new Date(news.published_date).toLocaleDateString(undefined, {
+                                    month: 'short',
+                                    day: 'numeric',
+                                  })}
+                                </time>
+                              )}
+                            </div>
                           </div>
                         </div>
-                      </div>
-                    </a>
-                  )),
-                )}
+                      </a>
+                    )),
+                  )}
               </div>
             </div>
           )}
@@ -637,7 +1837,7 @@ export const InteractiveStockChart = React.memo(
                               >
                                 Financial
                               </Badge>
-                              <span className="text-[9px] text-muted-foreground/80 truncate">{news.query}</span>
+                              <span className="text-[9px] text-muted-foreground/80 truncate">{group.query}</span>
                             </div>
                             <h4 className="text-xs font-medium line-clamp-2">{news.title}</h4>
 
@@ -680,11 +1880,110 @@ export const InteractiveStockChart = React.memo(
               </div>
             </div>
           )}
+
+          {/* Market Movers Section */}
+          {market_movers && (
+            <div className="mt-5 pt-4 border-t border-border/30">
+              <div className="flex items-center justify-between mb-3">
+                <div className="flex items-center gap-1.5">
+                  <Activity className="size-3.5 text-primary/80" />
+                  <h3 className="text-xs font-medium text-foreground/90">Market Movers</h3>
+                </div>
               </div>
-            </AccordionContent>
-          </AccordionItem>
-        </Accordion>
-      </div>
+
+              <Tabs defaultValue="gainers" className="w-full">
+                <TabsList className="grid w-full grid-cols-3 mb-3">
+                  <TabsTrigger value="gainers" className="text-xs">Top Gainers</TabsTrigger>
+                  <TabsTrigger value="losers" className="text-xs">Top Losers</TabsTrigger>
+                  <TabsTrigger value="active" className="text-xs">Most Active</TabsTrigger>
+                </TabsList>
+
+                {/* Gainers Tab */}
+                <TabsContent value="gainers">
+                  <div className="grid gap-2">
+                    {market_movers.gainers.map((stock, idx) => (
+                      <div key={idx} className="flex items-center justify-between p-2 rounded-md bg-card/40 border border-border/30 hover:bg-card/60 transition-colors">
+                        <div className="flex items-center gap-3">
+                          <Badge variant="outline" className="text-xs font-medium">
+                            {stock.symbol}
+                          </Badge>
+                          <span className="text-xs text-muted-foreground truncate max-w-[200px]">{stock.name}</span>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <span className="text-sm font-medium">${stock.last.toFixed(2)}</span>
+                          <Badge className="bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-400 text-xs">
+                            <TrendingUp className="size-3 mr-1" />
+                            +{stock.percent_change.toFixed(2)}%
+                          </Badge>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </TabsContent>
+
+                {/* Losers Tab */}
+                <TabsContent value="losers">
+                  <div className="grid gap-2">
+                    {market_movers.losers.map((stock, idx) => (
+                      <div key={idx} className="flex items-center justify-between p-2 rounded-md bg-card/40 border border-border/30 hover:bg-card/60 transition-colors">
+                        <div className="flex items-center gap-3">
+                          <Badge variant="outline" className="text-xs font-medium">
+                            {stock.symbol}
+                          </Badge>
+                          <span className="text-xs text-muted-foreground truncate max-w-[200px]">{stock.name}</span>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <span className="text-sm font-medium">${stock.last.toFixed(2)}</span>
+                          <Badge className="bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-400 text-xs">
+                            <TrendingDown className="size-3 mr-1" />
+                            {stock.percent_change.toFixed(2)}%
+                          </Badge>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </TabsContent>
+
+                {/* Most Active Tab */}
+                <TabsContent value="active">
+                  <div className="grid gap-2">
+                    {market_movers.most_active.map((stock, idx) => (
+                      <div key={idx} className="flex items-center justify-between p-2 rounded-md bg-card/40 border border-border/30 hover:bg-card/60 transition-colors">
+                        <div className="flex items-center gap-3">
+                          <Badge variant="outline" className="text-xs font-medium">
+                            {stock.symbol}
+                          </Badge>
+                          <span className="text-xs text-muted-foreground truncate max-w-[200px]">{stock.name}</span>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <span className="text-sm font-medium">${stock.last.toFixed(2)}</span>
+                          <Badge 
+                            className={cn(
+                              "text-xs",
+                              stock.percent_change >= 0 
+                                ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-400"
+                                : "bg-red-100 text-red-700 dark:bg-red-500/20 dark:text-red-400"
+                            )}
+                          >
+                            {stock.percent_change >= 0 ? <TrendingUp className="size-3 mr-1" /> : <TrendingDown className="size-3 mr-1" />}
+                            {stock.percent_change >= 0 ? '+' : ''}{stock.percent_change.toFixed(2)}%
+                          </Badge>
+                          <span className="text-[10px] text-muted-foreground">
+                            Vol: {(stock.volume / 1e6).toFixed(1)}M
+                          </span>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </TabsContent>
+              </Tabs>
+            </div>
+          )}
+        </div>
+      </AccordionContent>
+    </AccordionItem>
+  </Accordion>
+</div>
     );
   },
 );

--- a/components/message-parts/index.tsx
+++ b/components/message-parts/index.tsx
@@ -74,6 +74,127 @@ const CurrencyConverter = lazy(() =>
   import('@/components/currency_conv').then((module) => ({ default: module.CurrencyConverter })),
 );
 const InteractiveStockChart = lazy(() => import('@/components/interactive-stock-chart'));
+
+// Realistic animated loader component for stock chart
+const StockChartLoader = ({ title, input }: { title?: string; input?: any }) => {
+  const [currentStep, setCurrentStep] = useState(0);
+  const [completedSteps, setCompletedSteps] = useState<Set<number>>(new Set());
+  const [startTime] = useState(Date.now());
+
+  // Define realistic steps with expected durations
+  const allSteps = [
+    { id: 0, label: 'Stock prices', color: 'bg-emerald-500', duration: 2000, always: true, source: 'Valyu' },
+    { id: 1, label: 'Financial reports', color: 'bg-amber-500', duration: 3000, always: true, source: 'Exa' },
+    { id: 2, label: 'Market news', color: 'bg-purple-500', duration: 2500, always: true, source: 'Tavily' },
+    { 
+      id: 3, 
+      label: 'Company statistics', 
+      color: 'bg-cyan-500', 
+      duration: 1500,
+      show: input?.include_statistics,
+      source: 'Valyu'
+    },
+    { 
+      id: 4, 
+      label: 'Financial statements', 
+      color: 'bg-indigo-500', 
+      duration: 2000,
+      show: input?.include_balance_sheet || input?.include_income_statement || input?.include_cash_flow,
+      source: 'Valyu'
+    },
+    { 
+      id: 5, 
+      label: 'Dividend history', 
+      color: 'bg-green-500', 
+      duration: 1800,
+      show: input?.include_dividends,
+      source: 'Valyu'
+    },
+    { 
+      id: 6, 
+      label: 'Insider trades', 
+      color: 'bg-blue-500', 
+      duration: 2200,
+      show: input?.include_insider_transactions,
+      source: 'Valyu'
+    },
+    { 
+      id: 7, 
+      label: 'SEC filings', 
+      color: 'bg-red-500', 
+      duration: 4000,
+      show: input?.filing_types && input.filing_types.length > 0,
+      source: 'Valyu'
+    },
+    { 
+      id: 8, 
+      label: 'Market movers', 
+      color: 'bg-orange-500', 
+      duration: 1000,
+      show: input?.include_market_movers,
+      source: 'Valyu'
+    },
+  ];
+
+  const steps = allSteps.filter(step => step.always || step.show);
+
+  useEffect(() => {
+    let timeoutId: NodeJS.Timeout;
+    let stepStartTime = Date.now();
+
+    const advanceStep = () => {
+      setCurrentStep(prev => {
+        if (prev < steps.length - 1) {
+          setCompletedSteps(prevCompleted => {
+            const newCompleted = new Set(prevCompleted);
+            newCompleted.add(prev);
+            return newCompleted;
+          });
+          
+          const nextStep = prev + 1;
+          stepStartTime = Date.now();
+          
+          // Schedule next step
+          timeoutId = setTimeout(advanceStep, steps[nextStep]?.duration || 2000);
+          
+          return nextStep;
+        }
+        return prev;
+      });
+    };
+
+    // Start first step
+    if (steps.length > 0) {
+      timeoutId = setTimeout(advanceStep, steps[0]?.duration || 2000);
+    }
+
+    return () => {
+      if (timeoutId) clearTimeout(timeoutId);
+    };
+  }, [steps]);
+
+  const currentStepData = steps[currentStep];
+  const elapsedTime = Math.floor((Date.now() - startTime) / 1000);
+
+  return (
+    <div className="flex flex-col gap-3 w-full mt-4">
+      <Badge
+        variant="secondary"
+        className={cn(
+          'w-fit flex items-center gap-3 px-4 py-2 rounded-full transition-colors duration-200',
+          'bg-blue-200 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400',
+        )}
+      >
+        <TrendingUpIcon className="h-4 w-4" />
+        <span className="font-medium">
+          {title || 'Loading Stock Chart'}
+          {currentStepData && ` • Fetching ${currentStepData.label.toLowerCase()}`}
+        </span>
+        <Loader2 className="h-4 w-4 animate-spin" />
+      </Badge>
+    </div>
+  );
+};
 const CryptoChart = lazy(() =>
   import('@/components/crypto-charts').then((module) => ({ default: module.CryptoChart })),
 );
@@ -890,23 +1011,14 @@ const ToolPartRenderer = memo(
       case 'stock_chart':
         switch (part.state) {
           case 'input-streaming':
-            return <div className="text-sm text-neutral-500">Preparing stock chart...</div>;
-          case 'input-available':
             return (
-              <div className="flex flex-col gap-3 w-full mt-4">
-                <Badge
-                  variant="secondary"
-                  className={cn(
-                    'w-fit flex items-center gap-3 px-4 py-2 rounded-full transition-colors duration-200',
-                    'bg-blue-200 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400',
-                  )}
-                >
-                  <TrendingUpIcon className="h-4 w-4" />
-                  <span className="font-medium">{part.input?.title || 'Loading Stock Chart'}</span>
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                </Badge>
+              <div className="flex items-center gap-3 w-full mt-4 p-3 bg-muted/30 rounded-lg border border-border/40">
+                <TrendingUpIcon className="h-4 w-4 text-primary/80" />
+                <span className="text-sm text-muted-foreground">Preparing financial analysis...</span>
               </div>
             );
+          case 'input-available':
+            return <StockChartLoader title={part.input?.title} input={part.input} />;
           case 'output-available':
             return (
               <Suspense fallback={<ComponentLoader />}>
@@ -918,9 +1030,19 @@ const ToolPartRenderer = memo(
                   }}
                   data={part.output.chart.elements}
                   stock_symbols={part.input.stock_symbols}
-                  currency_symbols={part.input.currency_symbols || part.input.stock_symbols.map(() => 'USD')}
-                  interval={part.input.interval}
+                  currency_symbols={part.output.currency_symbols || part.input.currency_symbols || part.input.stock_symbols?.map(() => 'USD') || ['USD']}
+                  interval={part.input.time_period || part.input.interval || '1 year'}
+                  resolved_companies={part.output.resolved_companies}
+                  earnings_data={part.output.earnings_data}
                   news_results={part.output.news_results}
+                  sec_filings={part.output.sec_filings}
+                  company_statistics={part.output.company_statistics}
+                  balance_sheets={part.output.balance_sheets}
+                  income_statements={part.output.income_statements}
+                  cash_flows={part.output.cash_flows}
+                  dividends_data={part.output.dividends_data}
+                  insider_transactions={part.output.insider_transactions}
+                  market_movers={part.output.market_movers}
                 />
               </Suspense>
             );

--- a/lib/tools/stock-chart.ts
+++ b/lib/tools/stock-chart.ts
@@ -4,6 +4,7 @@ import { Valyu } from 'valyu-js';
 import { tavily } from '@tavily/core';
 import Exa from 'exa-js';
 import { serverEnv } from '@/env/server';
+import { isUserProCached } from '@/lib/subscription';
 
 const CURRENCY_SYMBOLS = {
   USD: '$',
@@ -48,12 +49,12 @@ interface NewsGroup {
 }
 
 export const stockChartTool = tool({
-  description: 'Get stock data and news for given stock symbols.',
+  description: 'Get stock data and news for companies using natural language. Valyu will resolve company names to stock tickers automatically.',
   inputSchema: z.object({
     title: z.string().describe('The title of the chart.'),
     news_queries: z.array(z.string()).describe('The news queries to search for.'),
     icon: z.enum(['stock', 'date', 'calculation', 'default']).describe('The icon to display for the chart.'),
-    stock_symbols: z.array(z.string()).describe('The stock symbols to display for the chart.'),
+    companies: z.array(z.string()).describe('Company names (e.g., "Apple", "Microsoft", "Tesla") - Valyu will resolve these to appropriate stock tickers.'),
     currency_symbols: z
       .array(z.string())
       .describe(
@@ -61,82 +62,460 @@ export const stockChartTool = tool({
           Object.keys(CURRENCY_SYMBOLS).join(', ') +
           '. Defaults to USD if not provided.',
       ),
-    interval: z
-      .enum(['1d', '5d', '1mo', '3mo', '6mo', '1y', '2y', '5y', '10y', 'ytd', 'max'])
-      .describe('The interval of the chart. default is 1y.'),
+    time_period: z
+      .string()
+      .describe('Natural language time period (e.g., "last 6 months", "past year", "2 weeks", "since January", "last quarter", "since IPO", "all time", "maximum available"). Defaults to "1 year".'),
+    filing_types: z
+      .array(z.enum(['10-K', '10-Q', '8-K']))
+      .optional()
+      .describe('SEC filing types to retrieve (10-K for annual reports, 10-Q for quarterly reports, 8-K for current reports). If not specified, SEC filings won\'t be fetched.'),
+    sections: z
+      .array(z.string())
+      .optional()
+      .describe('Specific sections to retrieve from SEC filings (e.g., "MD&A", "Risk Factors", "Business", "Financial Statements", "Controls and Procedures"). If not specified, returns full filings.'),
+    include_statistics: z
+      .boolean()
+      .optional()
+      .describe('Include comprehensive company statistics like P/E ratios, market cap, debt-to-equity, etc. Adds key financial metrics and ratios.'),
+    include_balance_sheet: z
+      .boolean()
+      .optional()
+      .describe('Include balance sheet data showing assets, liabilities, and shareholders equity. Available from 2020 onwards.'),
+    include_income_statement: z
+      .boolean()
+      .optional()
+      .describe('Include income statement data with revenue, expenses, and profitability metrics. Available from 2020 onwards.'),
+    include_cash_flow: z
+      .boolean()
+      .optional()
+      .describe('Include cash flow statement showing operating, investing, and financing activities. Available from 2020 onwards.'),
+    include_dividends: z
+      .boolean()
+      .optional()
+      .describe('Include historical dividend information and payment schedules.'),
+    include_insider_transactions: z
+      .boolean()
+      .optional()
+      .describe('Include recent insider trading activity and executive transactions.'),
+    include_market_movers: z
+      .boolean()
+      .optional()
+      .describe('Include today\'s biggest gainers, losers, and most active stocks in the market. Only use if user asks for it explicitly.'),
+    financial_period: z
+      .string()
+      .optional()
+      .describe('Time period for financial statements (e.g., "2020-2024", "last 3 years", "Q4 2023"). Defaults to latest available if not specified.'),
   }),
   execute: async ({
     title,
     icon,
-    stock_symbols,
+    companies,
     currency_symbols,
-    interval,
+    time_period = "1 year",
     news_queries,
+    filing_types,
+    sections,
+    include_statistics,
+    include_balance_sheet,
+    include_income_statement,
+    include_cash_flow,
+    include_dividends,
+    include_insider_transactions,
+    include_market_movers,
+    financial_period,
   }: {
     title: string;
     icon: string;
-    stock_symbols: string[];
+    companies: string[];
     currency_symbols?: string[];
-    interval: string;
+    time_period?: string;
     news_queries: string[];
+    filing_types?: Array<'10-K' | '10-Q' | '8-K'>;
+    sections?: string[];
+    include_statistics?: boolean;
+    include_balance_sheet?: boolean;
+    include_income_statement?: boolean;
+    include_cash_flow?: boolean;
+    include_dividends?: boolean;
+    include_insider_transactions?: boolean;
+    include_market_movers?: boolean;
+    financial_period?: string;
   }) => {
     console.log('Title:', title);
     console.log('Icon:', icon);
-    console.log('Stock symbols:', stock_symbols);
+    console.log('Companies:', companies);
     console.log('Currency symbols:', currency_symbols);
-    console.log('Interval:', interval);
+    console.log('Time period:', time_period);
+    console.log('Filing types:', filing_types);
+    console.log('Sections:', sections);
     console.log('News queries:', news_queries);
+    console.log('Financial options:', {
+      include_statistics,
+      include_balance_sheet,
+      include_income_statement,
+      include_cash_flow,
+      include_dividends,
+      include_insider_transactions,
+      include_market_movers,
+      financial_period,
+    });
 
-    let news_results: NewsGroup[] = [];
+    // Check if user is pro for premium features
+    const isProUser = await isUserProCached();
+    console.log('Pro user:', isProUser);
+    
+    // Override pro-only features if user is not pro
+    const actualIncludeEarnings = isProUser; // Earnings always require pro
+    const actualIncludeStatistics = isProUser && include_statistics;
+    const actualIncludeBalanceSheet = isProUser && include_balance_sheet;
+    const actualIncludeIncomeStatement = isProUser && include_income_statement;
+    const actualIncludeCashFlow = isProUser && include_cash_flow;
+    const actualIncludeDividends = isProUser && include_dividends;
+    const actualIncludeInsiderTransactions = isProUser && include_insider_transactions;
+    const actualIncludeMarketMovers = isProUser && include_market_movers;
+    const actualFilingTypes = isProUser ? filing_types : undefined;
 
+    // Initialize all API clients
     const tvly = tavily({ apiKey: serverEnv.TAVILY_API_KEY });
+    const exa = new Exa(serverEnv.EXA_API_KEY);
+    const valyu = new Valyu(serverEnv.VALYU_API_KEY);
 
-    const searchPromises = [];
+    // Calculate if we expect a lot of data to be returned
+    const hasMultipleDataSources = [
+      actualIncludeStatistics,
+      actualIncludeBalanceSheet,
+      actualIncludeIncomeStatement,
+      actualIncludeCashFlow,
+      actualIncludeDividends,
+      actualIncludeInsiderTransactions,
+      actualIncludeMarketMovers
+    ].filter(Boolean).length;
+
+    const isLargeDataRequest = hasMultipleDataSources >= 3 || 
+                              (actualFilingTypes && actualFilingTypes.length > 0 && hasMultipleDataSources >= 2) ||
+                              companies.length > 2;
+
+    // Use shorter response length for SEC filings when we expect large amounts of data
+    const secResponseLength = isLargeDataRequest ? 'short' : 'max';
+
+    // Build all API promises to run in parallel
+    const allPromises: Promise<any>[] = [];
+    const promiseMap = new Map<string, number>();
+    let promiseIndex = 0;
+
+    // 1. Tavily news search promises
+    const tavilyPromises: { query: string; topic: string; index: number }[] = [];
     for (const query of news_queries) {
-      searchPromises.push({
-        query,
-        topic: 'finance',
-        promise: tvly.search(query, {
+      tavilyPromises.push({ query, topic: 'finance', index: promiseIndex });
+      allPromises.push(
+        tvly.search(query, {
           topic: 'finance',
           days: 7,
           maxResults: 3,
           searchDepth: 'advanced',
-        }),
-      });
+        }).catch((err) => ({ results: [], error: err.message }))
+      );
+      promiseMap.set(`tavily-finance-${query}`, promiseIndex++);
 
-      searchPromises.push({
-        query,
-        topic: 'news',
-        promise: tvly.search(query, {
+      tavilyPromises.push({ query, topic: 'news', index: promiseIndex });
+      allPromises.push(
+        tvly.search(query, {
           topic: 'news',
           days: 7,
           maxResults: 3,
           searchDepth: 'advanced',
-        }),
+        }).catch((err) => ({ results: [], error: err.message }))
+      );
+      promiseMap.set(`tavily-news-${query}`, promiseIndex++);
+    }
+
+    // 2. Exa financial reports promises
+    const exaPromises: { company: string; index: number }[] = [];
+    companies.forEach((company) => {
+      exaPromises.push({ company, index: promiseIndex });
+      allPromises.push(
+        exa.searchAndContents(`${company} financial report analysis`, {
+            text: true,
+            category: 'financial report',
+            livecrawl: 'preferred',
+            type: 'hybrid',
+            numResults: 10,
+            summary: {
+              query: 'all important information relevent to the important for investors',
+            },
+        }).catch((error: any) => {
+          console.error(`Exa search error for ${company}:`, error);
+          return { results: [] };
+        })
+      );
+      promiseMap.set(`exa-${company}`, promiseIndex++);
+    });
+
+    // 3. Valyu core data promises (stock prices and earnings)
+    const stockQuery = `What are the stock prices for ${companies.join(' and ')} for time period ${time_period}?`;
+    
+    allPromises.push(
+      valyu.search(stockQuery, {
+        searchType: 'proprietary',
+        isToolCall: true,
+        includedSources: ['valyu/valyu-stocks-US'],
+        maxPrice: 100
+      }).catch((error) => {
+        console.error('Error fetching Valyu stock data:', error);
+        return null;
+      })
+    );
+    promiseMap.set('valyu-stocks', promiseIndex++);
+
+    // Only fetch earnings if user is pro
+    if (actualIncludeEarnings) {
+      const earningsQuery = `What are the earnings for ${companies.join(' and ')} for time period ${time_period}?`;
+      allPromises.push(
+        valyu.search(earningsQuery, {
+          searchType: 'proprietary',
+          isToolCall: true,
+          includedSources: ['valyu/valyu-earnings-US'],
+          maxPrice: 100
+        }).catch((error) => {
+          console.error('Error fetching Valyu earnings data:', error);
+          return null;
+        })
+      );
+      promiseMap.set('valyu-earnings', promiseIndex++);
+    }
+
+    // 4. SEC filings promises
+    const secPromises: { company: string; filingType: string; index: number }[] = [];
+    if (actualFilingTypes && actualFilingTypes.length > 0) {
+      companies.forEach(company => {
+        actualFilingTypes.forEach(filingType => {
+          let secQuery = `Get the full ${filingType} filing for ${company} for the time period "${time_period}"`;
+          if (sections && sections.length > 0) {
+            secQuery = `${company} sec filing ${filingType} ${sections.join(' and ')} for the time period "${time_period}"`;
+          }
+          
+          secPromises.push({ company, filingType, index: promiseIndex });
+          allPromises.push(
+            valyu.search(secQuery, {
+              searchType: 'proprietary',
+              isToolCall: true,
+              includedSources: ['valyu/valyu-sec-filings'],
+              responseLength: secResponseLength,
+              maxPrice: 100
+            }).catch((error) => {
+              console.error(`Error fetching ${filingType} for ${company}:`, error);
+              return null;
+            })
+          );
+          promiseMap.set(`sec-${company}-${filingType}`, promiseIndex++);
+        });
       });
     }
 
-    const searchResults = await Promise.all(
-      searchPromises.map(({ promise }) =>
-        promise.catch((err) => ({
-          results: [],
-          error: err.message,
-        })),
-      ),
-    );
+    // 5. Additional financial data promises
+    const financialPromises: { type: string; company?: string; index: number }[] = [];
 
+    // Company statistics
+    if (actualIncludeStatistics) {
+      companies.forEach(company => {
+        financialPromises.push({ type: 'statistics', company, index: promiseIndex });
+        allPromises.push(
+          valyu.search(`${company} company statistics`, {
+            searchType: 'proprietary',
+            isToolCall: true,
+            includedSources: ['valyu/valyu-statistics-US'],
+            maxPrice: 100
+          }).catch((error) => {
+            console.error(`Error fetching statistics for ${company}:`, error);
+            return null;
+          })
+        );
+        promiseMap.set(`stats-${company}`, promiseIndex++);
+      });
+    }
+
+    // Balance sheets
+    if (actualIncludeBalanceSheet) {
+      companies.forEach(company => {
+        const buildFinancialQuery = (company: string, statement: string) => {
+          if (financial_period) {
+            return `${company} ${statement} ${financial_period}`;
+          }
+          return `${company} ${statement}`;
+        };
+
+        financialPromises.push({ type: 'balance', company, index: promiseIndex });
+        allPromises.push(
+          valyu.search(buildFinancialQuery(company, 'balance sheet'), {
+            searchType: 'proprietary',
+            isToolCall: true,
+            includedSources: ['valyu/valyu-balance-sheet-US'],
+            maxPrice: 100
+          }).catch((error) => {
+            console.error(`Error fetching balance sheet for ${company}:`, error);
+            return null;
+          })
+        );
+        promiseMap.set(`balance-${company}`, promiseIndex++);
+      });
+    }
+
+    // Income statements
+    if (actualIncludeIncomeStatement) {
+      companies.forEach(company => {
+        const buildFinancialQuery = (company: string, statement: string) => {
+          if (financial_period) {
+            return `${company} ${statement} ${financial_period}`;
+          }
+          return `${company} ${statement}`;
+        };
+
+        financialPromises.push({ type: 'income', company, index: promiseIndex });
+        allPromises.push(
+          valyu.search(buildFinancialQuery(company, 'income statement'), {
+            searchType: 'proprietary',
+            isToolCall: true,
+            includedSources: ['valyu/valyu-income-statement-US'],
+            maxPrice: 100
+          }).catch((error) => {
+            console.error(`Error fetching income statement for ${company}:`, error);
+            return null;
+          })
+        );
+        promiseMap.set(`income-${company}`, promiseIndex++);
+      });
+    }
+
+    // Cash flows
+    if (actualIncludeCashFlow) {
+      companies.forEach(company => {
+        const buildFinancialQuery = (company: string, statement: string) => {
+          if (financial_period) {
+            return `${company} ${statement} ${financial_period}`;
+          }
+          return `${company} ${statement}`;
+        };
+
+        financialPromises.push({ type: 'cash', company, index: promiseIndex });
+        allPromises.push(
+          valyu.search(buildFinancialQuery(company, 'cash flow'), {
+            searchType: 'proprietary',
+            isToolCall: true,
+            includedSources: ['valyu/valyu-cash-flow-US'],
+            maxPrice: 100
+          }).catch((error) => {
+            console.error(`Error fetching cash flow for ${company}:`, error);
+            return null;
+          })
+        );
+        promiseMap.set(`cash-${company}`, promiseIndex++);
+      });
+    }
+
+    // Dividends
+    if (actualIncludeDividends) {
+      companies.forEach(company => {
+        financialPromises.push({ type: 'dividends', company, index: promiseIndex });
+        allPromises.push(
+          valyu.search(`${company} dividends ${time_period}`, {
+            searchType: 'proprietary',
+            isToolCall: true,
+            includedSources: ['valyu/valyu-dividends-US'],
+            maxPrice: 100
+          }).catch((error) => {
+            console.error(`Error fetching dividends for ${company}:`, error);
+            return null;
+          })
+        );
+        promiseMap.set(`dividends-${company}`, promiseIndex++);
+      });
+    }
+
+    // Insider transactions
+    if (actualIncludeInsiderTransactions) {
+      companies.forEach(company => {
+        const timeHint = time_period && time_period.trim().length > 0 ? time_period : 'recent';
+        financialPromises.push({ type: 'insider', company, index: promiseIndex });
+        allPromises.push(
+          valyu.search(`${company} insider transactions ${timeHint}`, {
+            searchType: 'proprietary',
+            isToolCall: true,
+            includedSources: ['valyu/valyu-insider-transactions-US'],
+            maxPrice: 100
+          }).catch((error) => {
+            console.error(`Error fetching insider transactions for ${company}:`, error);
+            return null;
+          })
+        );
+        promiseMap.set(`insider-${company}`, promiseIndex++);
+      });
+    }
+
+    // Market movers
+    if (actualIncludeMarketMovers) {
+      financialPromises.push({ type: 'gainers', index: promiseIndex });
+      allPromises.push(
+        valyu.search('top market gainers today stocks', {
+          searchType: 'proprietary',
+          isToolCall: true,
+          includedSources: ['valyu/valyu-market-movers-US'],
+          maxPrice: 100
+        }).catch((error) => {
+          console.error('Error fetching market gainers:', error);
+          return null;
+        })
+      );
+      promiseMap.set('gainers', promiseIndex++);
+
+      financialPromises.push({ type: 'losers', index: promiseIndex });
+      allPromises.push(
+        valyu.search('top market losers today stocks', {
+          searchType: 'proprietary',
+          isToolCall: true,
+          includedSources: ['valyu/valyu-market-movers-US'],
+          maxPrice: 100
+        }).catch((error) => {
+          console.error('Error fetching market losers:', error);
+          return null;
+        })
+      );
+      promiseMap.set('losers', promiseIndex++);
+
+      financialPromises.push({ type: 'active', index: promiseIndex });
+      allPromises.push(
+        valyu.search('most active stocks today', {
+          searchType: 'proprietary',
+          isToolCall: true,
+          includedSources: ['valyu/valyu-market-movers-US'],
+          maxPrice: 100
+        }).catch((error) => {
+          console.error('Error fetching most active stocks:', error);
+          return null;
+        })
+      );
+      promiseMap.set('active', promiseIndex++);
+    }
+
+    // Execute all promises in parallel
+    console.log(`Executing ${allPromises.length} API calls in parallel...`);
+    const allResults = await Promise.all(allPromises);
+
+    // Process results
+    let news_results: NewsGroup[] = [];
+
+    // Process Tavily results
     const urlSet = new Set();
-    searchPromises.forEach(({ query, topic }, index) => {
-      const result = searchResults[index];
+    tavilyPromises.forEach(({ query, topic, index }) => {
+      const result = allResults[index];
       if (!result.results) return;
 
       const processedResults = result.results
-        .filter((item) => {
+        .filter((item: any) => {
           if (urlSet.has(item.url)) return false;
           urlSet.add(item.url);
           return true;
         })
-        .map((item) => ({
+        .map((item: any) => ({
           title: item.title,
           url: item.url,
           content: item.content.slice(0, 30000),
@@ -154,34 +533,12 @@ export const stockChartTool = tool({
       }
     });
 
-    const exaResults: NewsGroup[] = [];
-    try {
-      const exa = new Exa(serverEnv.EXA_API_KEY);
-      const exaSearchPromises = stock_symbols.map((symbol) =>
-        exa
-          .searchAndContents(`${symbol} financial report analysis`, {
-            text: true,
-            category: 'financial report',
-            livecrawl: 'preferred',
-            type: 'hybrid',
-            numResults: 10,
-            summary: {
-              query: 'all important information relevent to the important for investors',
-            },
-          })
-          .catch((error: any) => {
-            console.error(`Exa search error for ${symbol}:`, error);
-            return { results: [] };
-          }),
-      );
-
-      const exaSearchResults = await Promise.all(exaSearchPromises);
-
+    // Process Exa results
       const exaUrlSet = new Set();
-      exaSearchResults.forEach((result: any, index: number) => {
+    exaPromises.forEach(({ company, index }) => {
+      const result = allResults[index];
         if (!result.results || result.results.length === 0) return;
 
-        const stockSymbol = stock_symbols[index];
         const processedResults = result.results
           .filter((item: any) => {
             if (exaUrlSet.has(item.url)) return false;
@@ -194,22 +551,17 @@ export const stockChartTool = tool({
             content: item.summary || '',
             published_date: item.publishedDate,
             category: 'financial',
-            query: stockSymbol,
+          query: company,
           }));
 
         if (processedResults.length > 0) {
-          exaResults.push({
-            query: stockSymbol,
+        news_results.push({
+          query: company,
             topic: 'financial',
             results: processedResults,
           });
         }
       });
-
-      news_results = [...news_results, ...exaResults];
-    } catch (error) {
-      console.error('Error fetching Exa financial reports:', error);
-    }
 
     type ValyuOHLC = {
       datetime: string;
@@ -218,6 +570,15 @@ export const stockChartTool = tool({
       low: number;
       close: number;
       volume: number;
+    };
+
+    type ValyuEarning = {
+      date: string;
+      time: string;
+      eps_estimate: number | null;
+      eps_actual: number;
+      difference: number | null;
+      surprise_prc: number | null;
     };
 
     type ValyuResult = {
@@ -235,45 +596,29 @@ export const stockChartTool = tool({
       };
     };
 
-    const sanitizeTicker = (symbol: string): string => {
-      const upper = symbol.toUpperCase();
-      const base = upper.split('.')[0];
-      return base.replace(/[^A-Z]/g, '');
-    };
-
-    const intervalToQueryRange = (raw: string): string => {
-      const mapping: Record<string, string> = {
-        '1d': '1 day',
-        '5d': '5 days',
-        '1mo': '1 month',
-        '3mo': '3 months',
-        '6mo': '6 months',
-        '1y': '1 year',
-        '2y': '2 years',
-        '5y': '5 years',
-        '10y': '10 years',
-        ytd: 'year to date',
-        max: 'max',
+    type ValyuEarningsResult = {
+      id?: string;
+      title: string;
+      url: string;
+      content: ValyuEarning[];
+      metadata?: {
+        symbol?: string;
+        name?: string;
+        start_date?: string;
+        end_date?: string;
+        timestamp?: string;
+        total_results?: number;
+        exchange?: string;
       };
-      return mapping[raw] ?? '5 years';
     };
 
-    const sanitizedTickers = stock_symbols.map(sanitizeTicker);
-    const rangeText = intervalToQueryRange(interval);
-
-    const valyu = new Valyu(serverEnv.VALYU_API_KEY);
-    const query = `What are the ${rangeText} historical stock prices for ${sanitizedTickers.join(
-      ' and ',
-    )}?`;
-
+    // Process Valyu stock and earnings results
     let valyuResults: ValyuResult[] = [];
-    try {
-      const response = await valyu.search(query, {
-        searchType: 'proprietary',
-        relevanceThreshold: 0.6,
-        isToolCall: false,
-        includedSources: ['valyu/valyu-stocks-US'],
-      });
+    let valyuEarningsResults: ValyuEarningsResult[] = [];
+    
+    const stockResponse = allResults[promiseMap.get('valyu-stocks')!];
+
+    console.log('Valyu stock response:', stockResponse);
 
       const isValyuOHLCArray = (value: unknown): value is ValyuOHLC[] => {
         return (
@@ -288,6 +633,19 @@ export const stockChartTool = tool({
         );
       };
 
+    const isValyuEarningsArray = (value: unknown): value is ValyuEarning[] => {
+      return (
+        Array.isArray(value) &&
+        value.every(
+          (v) =>
+            typeof v === 'object' &&
+            v !== null &&
+            'date' in (v as Record<string, unknown>) &&
+            'eps_actual' in (v as Record<string, unknown>),
+          )
+        );
+      };
+
       const isValyuResult = (obj: unknown): obj is ValyuResult => {
         if (!obj || typeof obj !== 'object') return false;
         const r = obj as Record<string, unknown>;
@@ -298,11 +656,25 @@ export const stockChartTool = tool({
         );
       };
 
-      if (response && Array.isArray(response.results)) {
-        valyuResults = (response.results as unknown[]).filter(isValyuResult) as ValyuResult[];
-      }
-    } catch (error) {
-      console.error('Error fetching Valyu data:', error);
+    const isValyuEarningsResult = (obj: unknown): obj is ValyuEarningsResult => {
+      if (!obj || typeof obj !== 'object') return false;
+      const r = obj as Record<string, unknown>;
+      return (
+        typeof r['title'] === 'string' &&
+        typeof r['url'] === 'string' &&
+        isValyuEarningsArray(r['content'])
+      );
+    };
+
+    // Process stock data
+    if (stockResponse && Array.isArray(stockResponse.results)) {
+      valyuResults = (stockResponse.results as unknown[]).filter(isValyuResult) as ValyuResult[];
+    }
+
+    // Process earnings data (only if user is pro)
+    const earningsResponse = actualIncludeEarnings ? allResults[promiseMap.get('valyu-earnings') || -1] : null;
+    if (earningsResponse && Array.isArray(earningsResponse.results)) {
+      valyuEarningsResults = (earningsResponse.results as unknown[]).filter(isValyuEarningsResult) as ValyuEarningsResult[];
     }
 
     const getTickerFromResult = (r: ValyuResult): string | undefined => {
@@ -317,14 +689,30 @@ export const stockChartTool = tool({
       return undefined;
     };
 
-    const elements = sanitizedTickers.map((ticker) => {
-      const resultForTicker = valyuResults.find((r) => getTickerFromResult(r) === ticker);
-      const points: Array<[string, number]> = (resultForTicker?.content || [])
+    const getTickerFromEarningsResult = (r: ValyuEarningsResult): string | undefined => {
+      if (r.metadata?.symbol) return r.metadata.symbol.toUpperCase();
+      if (r.id) {
+        const match = r.id.match(/valyu-earnings-US:([A-Z.]+)\s/);
+        if (match && match[1]) return match[1].split('.')[0];
+      }
+
+      const titleMatch = r.title.match(/([A-Z.]+)\s+Earnings/i);
+      if (titleMatch && titleMatch[1]) return titleMatch[1].toUpperCase().split('.')[0];
+      return undefined;
+    };
+
+    // Create chart elements using resolved tickers from Valyu
+    const elements = valyuResults.map((result) => {
+      const resolvedTicker = getTickerFromResult(result);
+      const companyName = result.metadata?.name || resolvedTicker || 'Unknown';
+      const points: Array<[string, number]> = result.content
         .map((c) => [c.datetime, Number(c.close)] as [string, number])
         .filter(([, close]) => Number.isFinite(close));
+      
       return {
-        label: ticker,
+        label: `${companyName} (${resolvedTicker})`,
         points,
+        ticker: resolvedTicker,
       };
     });
 
@@ -338,13 +726,409 @@ export const stockChartTool = tool({
       png: undefined,
     };
 
-    const outputCurrencyCodes = currency_symbols || stock_symbols.map(() => 'USD');
+    const outputCurrencyCodes = currency_symbols || elements.map(() => 'USD');
+
+    // Process earnings data
+    const earningsData = valyuEarningsResults.map((earningsResult) => {
+      const resolvedTicker = getTickerFromEarningsResult(earningsResult);
+      const companyName = earningsResult.metadata?.name || resolvedTicker || 'Unknown';
 
     return {
-      message: 'Fetched historical prices from Valyu (US)',
+        ticker: resolvedTicker,
+        companyName,
+        earnings: earningsResult.content.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()), // Sort by date desc
+        metadata: earningsResult.metadata,
+      };
+    });
+
+    // Fetch SEC filings from Valyu
+    // Type definitions for all financial data
+    type CompanyStatistics = {
+      valuations_metrics: {
+        market_capitalization: number;
+        enterprise_value: number;
+        trailing_pe: number;
+        forward_pe: number;
+        peg_ratio: number;
+        price_to_sales_ttm: number;
+        price_to_book_mrq: number;
+        enterprise_to_revenue: number;
+        enterprise_to_ebitda: number;
+      };
+      financials: {
+        fiscal_year_ends: string;
+        most_recent_quarter: string;
+        gross_margin: number;
+        profit_margin: number;
+        operating_margin: number;
+        return_on_assets_ttm: number;
+        return_on_equity_ttm: number;
+        income_statement: {
+          revenue_ttm: number;
+          revenue_per_share_ttm: number;
+          quarterly_revenue_growth: number;
+          gross_profit_ttm: number;
+          ebitda: number;
+          net_income_to_common_ttm: number;
+          diluted_eps_ttm: number;
+          quarterly_earnings_growth_yoy: number;
+        };
+        balance_sheet: {
+          total_cash_mrq: number;
+          total_cash_per_share_mrq: number;
+          total_debt_mrq: number;
+          total_debt_to_equity_mrq: number;
+          current_ratio_mrq: number;
+          book_value_per_share_mrq: number;
+        };
+        cash_flow: {
+          operating_cash_flow_ttm: number;
+          levered_free_cash_flow_ttm: number;
+        };
+      };
+      stock_statistics: {
+        shares_outstanding: number;
+        float_shares: number;
+        avg_10_volume: number;
+        avg_90_volume: number;
+        shares_short: number;
+        short_ratio: number;
+        short_percent_of_shares_outstanding: number;
+        percent_held_by_insiders: number;
+        percent_held_by_institutions: number;
+      };
+      stock_price_summary: {
+        fifty_two_week_low: number;
+        fifty_two_week_high: number;
+        fifty_two_week_change: number;
+        beta: number;
+        day_50_ma: number;
+        day_200_ma: number;
+      };
+      dividends_and_splits: {
+        forward_annual_dividend_rate: number;
+        forward_annual_dividend_yield: number;
+        trailing_annual_dividend_rate: number;
+        trailing_annual_dividend_yield: number;
+        "5_year_average_dividend_yield": number;
+        payout_ratio: number;
+        dividend_frequency: string;
+        dividend_date: string;
+        ex_dividend_date: string;
+        last_split_factor: string;
+        last_split_date: string;
+      };
+    };
+
+    type BalanceSheetItem = {
+      fiscal_date: string;
+      year: number;
+      assets: {
+        current_assets: {
+          cash: number | null;
+          cash_equivalents: number | null;
+          cash_and_cash_equivalents: number;
+          other_short_term_investments: number;
+          accounts_receivable: number;
+          other_receivables: number | null;
+          inventory: number;
+          prepaid_assets: number | null;
+          restricted_cash: number | null;
+          assets_held_for_sale: number | null;
+          hedging_assets: number | null;
+          other_current_assets: number;
+          total_current_assets: number;
+        };
+        non_current_assets: {
+          properties: number;
+          land_and_improvements: number;
+          machinery_furniture_equipment: number;
+          construction_in_progress: number;
+          leases: number | null;
+          accumulated_depreciation: number;
+          goodwill: number;
+          investment_properties: number | null;
+          financial_assets: number | null;
+          intangible_assets: number;
+          investments_and_advances: number;
+          other_non_current_assets: number;
+          total_non_current_assets: number;
+        };
+        total_assets: number;
+      };
+      liabilities: {
+        current_liabilities: {
+          accounts_payable: number;
+          accrued_expenses: number | null;
+          short_term_debt: number;
+          deferred_revenue: number | null;
+          tax_payable: number;
+          pensions: number;
+          other_current_liabilities: number;
+          total_current_liabilities: number;
+        };
+        non_current_liabilities: {
+          long_term_provisions: number | null;
+          long_term_debt: number;
+          provision_for_risks_and_charges: number;
+          deferred_liabilities: number;
+          derivative_product_liabilities: number;
+          other_non_current_liabilities: number;
+          total_non_current_liabilities: number;
+        };
+        total_liabilities: number;
+      };
+      shareholders_equity: {
+        common_stock: number;
+        retained_earnings: number;
+        other_shareholders_equity: number;
+        total_shareholders_equity: number;
+        additional_paid_in_capital: number;
+        treasury_stock: number;
+        minority_interest: number;
+      };
+    };
+
+    type IncomeStatementItem = {
+      fiscal_date: string;
+      quarter?: number;
+      year: number;
+      sales: number;
+      cost_of_goods: number;
+      gross_profit: number;
+      operating_expense: {
+        research_and_development: number;
+        selling_general_and_administrative: number;
+        other_operating_expenses: number | null;
+      };
+      operating_income: number;
+      non_operating_interest: {
+        income: number;
+        expense: number;
+      };
+      other_income_expense: number;
+      pretax_income: number;
+      income_tax: number;
+      net_income: number;
+      eps_basic: number;
+      eps_diluted: number;
+      basic_shares_outstanding: number;
+      diluted_shares_outstanding: number;
+      ebit: number;
+      ebitda: number;
+      net_income_continuous_operations: number;
+      minority_interests: number;
+      preferred_stock_dividends: number | null;
+    };
+
+    type CashFlowItem = {
+      fiscal_date: string;
+      year: number;
+      operating_activities: {
+        net_income: number;
+        depreciation: number;
+        deferred_taxes: number;
+        stock_based_compensation: number;
+        other_non_cash_items: number;
+        accounts_receivable: number;
+        accounts_payable: number;
+        other_assets_liabilities: number;
+        operating_cash_flow: number;
+      };
+      investing_activities: {
+        capital_expenditures: number;
+        net_intangibles: number | null;
+        net_acquisitions: number;
+        purchase_of_investments: number;
+        sale_of_investments: number;
+        other_investing_activity: number | null;
+        investing_cash_flow: number;
+      };
+      financing_activities: {
+        long_term_debt_issuance: number;
+        long_term_debt_payments: number;
+        short_term_debt_issuance: number;
+        common_stock_issuance: number | null;
+        common_stock_repurchase: number;
+        common_dividends: number;
+        other_financing_charges: number;
+        financing_cash_flow: number;
+      };
+      end_cash_position: number;
+      income_tax_paid: number;
+      interest_paid: number;
+      free_cash_flow: number;
+    };
+
+    type DividendData = {
+      ex_date: string;
+      amount: number;
+    };
+
+    type InsiderTransaction = {
+      full_name: string;
+      position: string;
+      date_reported: string;
+      is_direct: boolean;
+      shares: number;
+      value: number;
+      description: string;
+    };
+
+    type MarketMover = {
+      symbol: string;
+      name: string;
+      exchange: string;
+      mic_code: string;
+      datetime: string;
+      last: number;
+      high: number;
+      low: number;
+      volume: number;
+      change: number;
+      percent_change: number;
+    };
+
+    type SECFiling = {
+      id?: string;
+      title: string;
+      url: string;
+      content: string;
+      metadata?: {
+        accession_number?: string;
+        full_filing?: boolean;
+        filing_date?: string; // YYYYMMDD format
+        date?: string; // YYYY-MM-DD format (alternative field)
+        document_type?: string;
+        form_type?: string; // Alternative field name
+        name?: string;
+        ticker?: string;
+        cik?: string;
+        part?: string;
+        item?: string;
+        timestamp?: string;
+      };
+    };
+
+    // Process SEC filings from parallel results  
+    let secFilings: SECFiling[] = [];
+    if (actualFilingTypes && actualFilingTypes.length > 0) {
+      const rawFilings: any[] = [];
+      
+      secPromises.forEach(({ company, filingType, index }) => {
+        const response = allResults[index];
+        if (response && Array.isArray(response.results)) {
+          const filings = response.results.map((result: any) => ({
+            ...result,
+            requestedCompany: company,
+            requestedFilingType: filingType
+          }));
+          rawFilings.push(...filings);
+        }
+      });
+
+      // Truncate SEC filing content if we have a lot of data to prevent token limit issues
+      const maxFilingLength = isLargeDataRequest ? 15000 : 50000; // Shorter when lots of other data
+      
+      secFilings = rawFilings
+        .filter(filing => filing && filing.content)
+        .map(filing => ({
+          id: filing.id,
+          title: filing.title,
+          url: filing.url,
+          content: filing.content.length > maxFilingLength 
+            ? filing.content.substring(0, maxFilingLength) + '\n\n[Content truncated due to length...]'
+            : filing.content,
+          metadata: filing.metadata,
+          requestedCompany: filing.requestedCompany,
+          requestedFilingType: filing.requestedFilingType
+        }));
+
+      console.log('SEC filings fetched:', secFilings.length);
+      console.log('Using response length:', secResponseLength, '| Large data request:', isLargeDataRequest);
+    }
+
+    // Process additional financial data from parallel results
+    let companyStatistics: Record<string, CompanyStatistics> = {};
+    let balanceSheets: Record<string, BalanceSheetItem[]> = {};
+    let incomeStatements: Record<string, IncomeStatementItem[]> = {};
+    let cashFlows: Record<string, CashFlowItem[]> = {};
+    let dividendsData: Record<string, DividendData[]> = {};
+    let insiderTransactions: Record<string, InsiderTransaction[]> = {};
+    let marketMovers: { gainers: MarketMover[]; losers: MarketMover[]; most_active: MarketMover[] } = {
+      gainers: [],
+      losers: [],
+      most_active: []
+    };
+
+    // Process all financial data results
+    financialPromises.forEach(({ type, company, index }) => {
+      const response = allResults[index];
+      if (!response || !response.results || !response.results[0]) return;
+
+      const result = response.results[0];
+      
+      switch (type) {
+        case 'statistics':
+          if (company) {
+            companyStatistics[company] = result.content as unknown as CompanyStatistics;
+          }
+          break;
+        case 'balance':
+          if (company) {
+            balanceSheets[company] = result.content as unknown as BalanceSheetItem[];
+          }
+          break;
+        case 'income':
+          if (company) {
+            incomeStatements[company] = result.content as unknown as IncomeStatementItem[];
+          }
+          break;
+        case 'cash':
+          if (company) {
+            cashFlows[company] = result.content as unknown as CashFlowItem[];
+          }
+          break;
+        case 'dividends':
+          if (company) {
+            dividendsData[company] = result.content as unknown as DividendData[];
+          }
+          break;
+        case 'insider':
+          if (company) {
+            insiderTransactions[company] = result.content as unknown as InsiderTransaction[];
+          }
+          break;
+        case 'gainers':
+          marketMovers.gainers = (result.content as unknown as MarketMover[]).slice(0, 10);
+          break;
+        case 'losers':
+          marketMovers.losers = (result.content as unknown as MarketMover[]).slice(0, 10);
+          break;
+        case 'active':
+          marketMovers.most_active = (result.content as unknown as MarketMover[]).slice(0, 10);
+          break;
+      }
+    });
+
+    return {
+      message: `Fetched historical prices and earnings from Valyu for ${elements.length} companies over ${time_period}${sections && sections.length > 0 ? `, including SEC filing sections: ${sections.join(', ')}` : ''}`,
       chart: chartData,
       currency_symbols: outputCurrencyCodes,
       news_results: news_results,
+      resolved_companies: elements.map(el => ({
+        name: el.label,
+        ticker: el.ticker,
+      })),
+      earnings_data: earningsData,
+      sec_filings: secFilings,
+      company_statistics: companyStatistics,
+      balance_sheets: balanceSheets,
+      income_statements: incomeStatements,
+      cash_flows: cashFlows,
+      dividends_data: dividendsData,
+      insider_transactions: insiderTransactions,
+      market_movers: include_market_movers ? marketMovers : undefined,
     };
   },
 });


### PR DESCRIPTION
# Stocks mode upgrade

## New features:

### Backend:
- Flexible stock price interval: agent can now pass natural language time interval to get stocks over any date range (e.g. "since covid" or "from 4th june 2018 to 24th may 2020")
- Agentic finance data selector: In stocks mode, the stocks tool now allows the agent to pass whether it needs fonancial data beyond stock prices + news to properly answer user query - with access to dividends/income statements/sec filings/cash flow, and more (**NOTE:** by default stocks mode will just return stock data, news, and financial reports as usual, only if the agent deems necessary will it fetch other data)
- Extra financial data available for pro only? (can be changed)

### Frontend:
- Clean UI display for extra stock data if the agent decides necessary to answer user query
- Small UI adjustment to stock mode loader to show data it is currently fetching (news, reports, etc)


## Examples:

### Dividends analysis:
<img width="487" height="731" alt="Screenshot 2025-08-16 at 23 38 00" src="https://github.com/user-attachments/assets/f11987dc-c5b1-4fcb-bdb3-db9d6d731ba7" />

### Insider trades analysis:
<img width="514" height="799" alt="Screenshot 2025-08-16 at 23 41 01" src="https://github.com/user-attachments/assets/58396886-eb19-45f3-ab2f-33049ea72dfb" />

<img width="451" height="158" alt="Screenshot 2025-08-16 at 23 41 16" src="https://github.com/user-attachments/assets/67b23cd3-99c4-49a1-8f44-7fbbf3c1dd48" />

### SEC filing analysis (specific parts of 10-k/10-q/8-k)
<img width="499" height="616" alt="Screenshot 2025-08-16 at 23 44 37" src="https://github.com/user-attachments/assets/560dcd5f-5c9a-4938-81b0-7eeb553059bb" />

<img width="1355" height="799" alt="Screenshot 2025-08-16 at 23 44 49" src="https://github.com/user-attachments/assets/2cde250d-0d5a-4b40-9c24-bbde3b918ae3" />
<img width="433" height="305" alt="Screenshot 2025-08-16 at 23 45 04" src="https://github.com/user-attachments/assets/8a98de07-e415-4cc3-b6f8-99b02b61806b" />



### Deep company research:
<img width="326" height="809" alt="Screenshot 2025-08-16 at 23 39 18" src="https://github.com/user-attachments/assets/dace22ec-9dd9-4dea-af63-a7c3d76ea8f1" />
