### PR TITLE
fix: remove .env file copy requirement from Dockerfile for Railway de…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,8 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 # Copy all source files
 COPY . .
-# Copy environment variables for build configuration
-COPY .env .env
+# Note: Environment variables are provided by Railway at build and runtime
+# No need to copy .env file - use Railway's environment variable configuration
 # Build the Next.js application
 RUN npm run build
 


### PR DESCRIPTION
…ployment

The Dockerfile was attempting to copy a .env file during build, which fails on Railway since .env files are not committed to git. Railway provides environment variables through its platform configuration instead.

This change removes the COPY .env .env instruction and adds a comment explaining that environment variables are provided by Railway at build and runtime.

Fixes the deployment error:
ERROR: failed to compute cache key: "/.env": not found